### PR TITLE
ci(release): publish packages and Docker images when release-please cuts a tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ on:
       tag:
         description: "Release tag (e.g. v0.0.1) — used for backfill/manual publish"
         required: true
+      floating_tags:
+        description: "Also move the pg<N> and latest tags to this release (set by release-please for new releases; leave off for backfills)"
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -84,8 +88,8 @@ jobs:
           tags: |
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg }}
             type=raw,value=${{ steps.shortver.outputs.value }}-pg${{ matrix.pg }}
-            type=raw,value=pg${{ matrix.pg }},enable=${{ github.event_name == 'push' }}
-            type=raw,value=latest,enable=${{ matrix.pg == 18 && github.event_name == 'push' }}
+            type=raw,value=pg${{ matrix.pg }},enable=${{ github.event_name == 'push' || inputs.floating_tags == true }}
+            type=raw,value=latest,enable=${{ matrix.pg == 18 && (github.event_name == 'push' || inputs.floating_tags == true) }}
           labels: |
             org.opencontainers.image.title=ulak
             org.opencontainers.image.description=PostgreSQL ${{ matrix.pg }} with ulak extension

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -20,3 +21,19 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # release-please tags with GITHUB_TOKEN, and GitHub does not run tag-push
+  # workflows for events created by that token. workflow_dispatch is the
+  # documented exception, so trigger the packaging workflows explicitly.
+  dispatch-release-workflows:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - name: Package and publish the release
+        run: gh workflow run release.yml --repo "$GITHUB_REPOSITORY" -f "tag=$TAG"
+      - name: Publish Docker images
+        run: gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" -f "tag=$TAG" -f "floating_tags=true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to package (e.g. v0.1.0)"
+        required: true
+
+# Tags pushed by release-please with GITHUB_TOKEN do not trigger tag-push
+# workflows, so release-please.yml dispatches this workflow with the tag.
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 permissions:
   contents: write
@@ -16,13 +26,19 @@ jobs:
       archive: ${{ steps.archive.outputs.path }}
       version: ${{ steps.version.outputs.value }}
     steps:
-      - name: Check out the repo
+      - name: Check out the release tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Extract version from tag
         id: version
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$RELEASE_TAG" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' is not of the form vX.Y.Z"
+            exit 1
+          fi
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches version.txt
@@ -49,6 +65,7 @@ jobs:
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: ${{ steps.archive.outputs.path }}
           generate_release_notes: true
 

--- a/Dockerfile.publish
+++ b/Dockerfile.publish
@@ -30,12 +30,19 @@ FROM postgres:${PG_MAJOR}
 
 ARG PG_MAJOR=18
 
+# Runtime libraries for every dispatcher. hiredis, nats and OpenSSL carry the
+# soversion in the Debian package name (libhiredis1.1.0, libnats3.10,
+# libssl3t64 ...), so resolve those names from the base image's apt index
+# instead of pinning them; apt then pulls their own dependencies
+# (libprotobuf-c, libsodium for cnats) that a bare COPY would miss.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4 \
     librdkafka1 \
     libmosquitto1 \
     librabbitmq4 \
-    libssl3t64 \
+    "$(apt-cache search --names-only '^libssl[0-9]+(t64)?$' | awk '{print $1}' | sort | tail -1)" \
+    "$(apt-cache search --names-only '^libhiredis[0-9.]+$' | awk '{print $1}' | sort | tail -1)" \
+    "$(apt-cache search --names-only '^libnats[0-9.]+$' | awk '{print $1}' | sort | tail -1)" \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy compiled extension from builder
@@ -46,9 +53,10 @@ COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/ulak.control \
 COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/ulak--*.sql \
      /usr/share/postgresql/${PG_MAJOR}/extension/
 
-# libnats and libhiredis have no stable Debian package names — copy from builder
-COPY --from=builder /usr/lib/*/libnats.so* /usr/lib/
-COPY --from=builder /usr/lib/*/libhiredis.so* /usr/lib/
+# Fail the build if any shared library ulak.so needs is missing: the library
+# is in shared_preload_libraries, so a missing dependency means the server
+# does not start at all (this is what broke the 0.0.3 images).
+RUN ! ldd /usr/lib/postgresql/${PG_MAJOR}/lib/ulak.so | grep 'not found'
 
 # Auto-load extension via shared_preload_libraries
 RUN echo "shared_preload_libraries = 'ulak'" >> /usr/share/postgresql/postgresql.conf.sample

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,23 +66,28 @@
         },
         {
           "type": "docs",
-          "section": "Documentation"
+          "section": "Documentation",
+          "hidden": true
         },
         {
           "type": "ci",
-          "section": "Continuous Integration"
+          "section": "Continuous Integration",
+          "hidden": true
         },
         {
           "type": "build",
-          "section": "Build System"
+          "section": "Build System",
+          "hidden": true
         },
         {
           "type": "test",
-          "section": "Tests"
+          "section": "Tests",
+          "hidden": true
         },
         {
           "type": "chore",
-          "section": "Miscellaneous"
+          "section": "Miscellaneous",
+          "hidden": true
         }
       ]
     }


### PR DESCRIPTION
## Summary

Make releases actually ship: release-please's tag now dispatches the packaging (`release.yml`) and Docker (`publish.yml`) workflows, and the published image is fixed so PostgreSQL can load `ulak.so`.

## Why

- `v0.0.3` and `v0.1.0` have no release archive, PGXN upload or Docker images: tags created by release-please with `GITHUB_TOKEN` never trigger `on: push: tags` workflows. `workflow_dispatch` is the documented exception, so `release-please.yml` now dispatches both workflows with the new tag; `release.yml` gains a `tag` input (also usable for manual backfills) and `publish.yml` a `floating_tags` input so dispatched releases still move `pg<N>`/`latest`.
- The 0.0.3 image verification jobs failed because the runtime stage copied `libhiredis`/`libnats` but not `libhiredis_ssl`, `libprotobuf-c` and `libsodium`; with `ulak` in `shared_preload_libraries` the server did not start at all. Runtime packages are now installed through apt (soversion-suffixed names resolved from the base image) and the build fails if `ldd` still reports a missing library.
- Listing docs/ci/chore in `changelog-sections` made release-please treat a docs-only commit as releasable (it opened a 0.1.1 PR). Those types are hidden again; feat/fix/perf/refactor stay visible.

## Validation

- [x] `make format` (no C/SQL change)
- [x] `make lint` (no C/SQL change)
- [x] `make hooks-run` or local `lefthook` hooks (workflows validated with actionlint; YAML/JSON parsed)
- [x] `make installcheck` (no C/SQL change)

`Dockerfile.publish` built locally for PG 18 and PG 14: `ldd` reports no missing library, the container starts, `CREATE EXTENSION ulak`, `ulak.health_check()` and `validate_endpoint_config()` succeed, 4 workers running.

## Checklist

- [x] Tests added or updated when behavior changed (build-time `ldd` guard)
- [x] Docs updated when user-facing behavior or operations changed (n/a)
- [x] Commit messages follow the repository convention
- [x] This PR is ready for review