### PR TITLE
fix(sql): add the 0.1.0 -> 0.1.1 and 0.1.1 -> 0.1.2 upgrade paths

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,16 @@ env:
     libssl-dev
 
 jobs:
+  # Catches a release PR whose version.txt has no upgrade script reaching it
+  # (and any other version/metadata mismatch) before the tag is cut, since
+  # release.yml would otherwise fail after the release already exists.
+  release-metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/release_check.py
+
   static-analysis:
     if: ${{ !github.event.pull_request.draft }}
     name: Static Analysis

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -70,8 +70,9 @@ def check_upgrade_chain(version: str, errors: list[str]) -> None:
     if current != version:
         errors.append(
             f"no upgrade path from {start} to version.txt={version}: "
-            f"the chain stops at {current} (expected a sql/ulak--{current}--<next>.sql "
-            f"step that eventually reaches {version})"
+            f"the chain stops at {current}. Add sql/ulak--{current}--{version}.sql "
+            f"(SELECT 1; when the schema did not change) to main before merging the "
+            f"release PR; PostgreSQL cannot ALTER EXTENSION ulak UPDATE without it"
         )
 
     for src, targets in steps.items():

--- a/sql/ulak--0.1.0--0.1.1.sql
+++ b/sql/ulak--0.1.0--0.1.1.sql
@@ -1,0 +1,4 @@
+-- ulak 0.1.0 -> 0.1.1 upgrade migration
+-- No schema changes between 0.1.0 and 0.1.1 (Docker image fix only); this
+-- script exists so ALTER EXTENSION ulak UPDATE has a path from 0.1.0.
+SELECT 1;

--- a/sql/ulak--0.1.1--0.1.2.sql
+++ b/sql/ulak--0.1.1--0.1.2.sql
@@ -1,0 +1,4 @@
+-- ulak 0.1.1 -> 0.1.2 upgrade migration
+-- No schema changes between 0.1.1 and 0.1.2 (upgrade-path and CI fixes only);
+-- this script exists so ALTER EXTENSION ulak UPDATE has a path from 0.1.1.
+SELECT 1;


### PR DESCRIPTION
## Summary

Add the missing no-op upgrade scripts so 0.1.0 and 0.1.1 installations can `ALTER EXTENSION ulak UPDATE`, and run `scripts/release_check.py` on pull requests.

## Why

`v0.1.1` was tagged without `sql/ulak--0.1.0--0.1.1.sql`; PostgreSQL needs a script between every pair of versions, so 0.1.0 databases cannot upgrade to 0.1.1 and the dispatched packaging run failed on the upgrade-chain check. Running the check in PR CI makes a release PR fail before the tag exists.

## Validation

- [x] `make format` (no C change)
- [x] `make lint` (no C change)
- [x] `make hooks-run` or local `lefthook` hooks (n/a)
- [x] `make installcheck` (no C/SQL logic change)

`scripts/release_check.py` passes at 0.1.1 and, in a scratch copy with version.txt bumped, at 0.1.2.

## Checklist

- [x] Tests added or updated when behavior changed (release metadata check in PR CI)
- [x] Docs updated when user-facing behavior or operations changed (n/a)
- [x] Commit messages follow the repository convention
- [x] This PR is ready for review