### PR TITLE
ci(release): attach the archive with gh instead of updating the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,18 @@ jobs:
           name: pgxn-release-archive
           path: ${{ steps.archive.outputs.path }}
 
-      - name: Create or update GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          files: ${{ steps.archive.outputs.path }}
-          generate_release_notes: true
+      # release-please already created the GitHub release for the tag; only
+      # attach the archive. softprops/action-gh-release tried to update the
+      # release object as well, which the workflow token is not allowed to do
+      # for older releases (backfills failed with "Resource not accessible").
+      - name: Attach archive to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --generate-notes --verify-tag
+          fi
+          gh release upload "$RELEASE_TAG" "${{ steps.archive.outputs.path }}" --repo "$GITHUB_REPOSITORY" --clobber
 
   pgxn-publish:
     name: Publish to PGXN


### PR DESCRIPTION
## Summary

Replace `softprops/action-gh-release` in `release.yml` with `gh release upload`.

## Why

The action also updates the release object; for releases older than the current one the workflow token gets "Resource not accessible by integration", so the `v0.0.3` backfill failed after the archive was built and PGXN publishing was skipped. Uploading the asset is all that is needed because release-please already created the release.

## Validation

- [x] `make format` (no code change)
- [x] `make lint` (no code change)
- [x] `make hooks-run` or local `lefthook` hooks (actionlint on the workflow)
- [x] `make installcheck` (no code change)

## Checklist

- [x] Tests added or updated when behavior changed (n/a)
- [x] Docs updated when user-facing behavior or operations changed (n/a)
- [x] Commit messages follow the repository convention
- [x] This PR is ready for review