### PR TITLE
feat(worker)!: wake by latch at commit, deliver outside the claim transaction, bound Redis DNS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,10 @@ jobs:
           # this gate decorative. `|| rc=$?` lets the notice line still run.
           set -o pipefail
           rc=0
+          # One clang-tidy process per core (xargs -P), a few files each; xargs
+          # exits 123 when any invocation fails, so the gate still trips.
           find src -name "*.c" | \
-            xargs clang-tidy-22 -p . \
+            xargs -P "$(nproc)" -n 4 clang-tidy-22 -p . \
               --warnings-as-errors='clang-analyzer-core.*,bugprone-null-dereference' \
               2>&1 | tee clang-tidy-output.txt || rc=$?
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: Main CI
 
+# Every commit reaches main through a pull request whose full PG 14-18 matrix,
+# sanitizers, static analysis and clang-tidy are required checks, and the
+# ruleset requires the branch to be up to date with main, so the merged tree
+# is exactly the tree that was tested. A push to main therefore only runs a
+# PG 18 smoke pass (regress + isolation + TAP) as a signal for the status
+# line; the full matrix is available on demand through workflow_dispatch.
+
 on:
   push:
     branches: [main]
@@ -21,8 +28,42 @@ env:
     libssl-dev
 
 jobs:
-  # ── Regression + isolation tests across PG 14-18 ──
+  # ── Smoke pass on every push to main: PG 18 only ──
+  smoke-regress:
+    if: github.event_name == 'push'
+    name: PG 18 — Regress (smoke)
+    uses: ./.github/workflows/_reusable-regression.yml
+    with:
+      pg-version: 18
+      make-flags: ENABLE_KAFKA=1 ENABLE_MQTT=1 ENABLE_REDIS=1 ENABLE_AMQP=1 ENABLE_NATS=1
+      protocol-deps: >-
+        libcurl4-openssl-dev
+        librdkafka-dev
+        libhiredis-dev
+        libmosquitto-dev
+        librabbitmq-dev
+        libnats-dev
+        libssl-dev
+
+  smoke-tap:
+    if: github.event_name == 'push'
+    name: PG 18 — TAP (smoke)
+    uses: ./.github/workflows/_reusable-tap.yml
+    with:
+      pg-version: 18
+      make-flags: ENABLE_KAFKA=1 ENABLE_MQTT=1 ENABLE_REDIS=1 ENABLE_AMQP=1 ENABLE_NATS=1
+      protocol-deps: >-
+        libcurl4-openssl-dev
+        librdkafka-dev
+        libhiredis-dev
+        libmosquitto-dev
+        librabbitmq-dev
+        libnats-dev
+        libssl-dev
+
+  # ── Full matrix, on demand (workflow_dispatch) ──
   regress:
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +82,8 @@ jobs:
         libnats-dev
         libssl-dev
 
-  # ── TAP lifecycle tests across PG 14-18 ──
   tap:
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -61,14 +102,15 @@ jobs:
         libnats-dev
         libssl-dev
 
-  # ── Static analysis: cppcheck + clang-format ──
   static-analysis:
+    if: github.event_name == 'workflow_dispatch'
     name: Static Analysis
     uses: ./.github/workflows/_reusable-static-analysis.yml
 
   # ── clang-tidy: deep AST-based analysis ──
   clang-tidy:
     name: clang-tidy
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -120,8 +162,8 @@ jobs:
           name: clang-tidy-report
           path: clang-tidy-output.txt
 
-  # ── AddressSanitizer + UndefinedBehaviorSanitizer ──
   sanitizers:
+    if: github.event_name == 'workflow_dispatch'
     name: ASan + UBSan
     uses: ./.github/workflows/_reusable-sanitizers.yml
     with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,8 +137,10 @@ jobs:
           # this gate decorative. `|| rc=$?` lets the notice line still run.
           set -o pipefail
           rc=0
+          # One clang-tidy process per core (xargs -P), a few files each; xargs
+          # exits 123 when any invocation fails, so the gate still trips.
           find src -name "*.c" | \
-            xargs clang-tidy-22 -p . \
+            xargs -P "$(nproc)" -n 4 clang-tidy-22 -p . \
               --warnings-as-errors='clang-analyzer-core.*,bugprone-null-dereference' \
               2>&1 | tee clang-tidy-output.txt || rc=$?
           echo ""

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifdef ENABLE_REDIS
     OBJS += src/dispatchers/redis/redis_connection.o
     OBJS += src/dispatchers/redis/redis_tls.o
     PG_CPPFLAGS += -DENABLE_REDIS
-    SHLIB_LINK += -lhiredis -lhiredis_ssl -lssl -lcrypto
+    SHLIB_LINK += -lhiredis -lhiredis_ssl -lssl -lcrypto -lpthread
 endif
 
 ifdef ENABLE_AMQP

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ MODULE_big = $(EXTENSION)
 OBJS = src/ulak.o
 OBJS += src/worker.o
 OBJS += src/shmem.o
+OBJS += src/wake.o
 
 # Modular architecture objects
 OBJS += src/core/entities.o
@@ -205,7 +206,7 @@ REGRESS = 00_setup 01_schema 02_endpoints_crud 03_endpoints_validation \
           15_production_hardening 16_message_lifecycle 17_cloudevents \
           18_advanced_operations 19_http_proxy 20_kafka_config 21_redis_config \
           22_mqtt_config 23_amqp_config 24_nats_config \
-          25_metrics 99_cleanup
+          25_metrics 26_wake 99_cleanup
 
 # Test options: use tests/regress/ subdirectory for input/output, dedicated test database
 REGRESS_OPTS = --inputdir=tests/regress --outputdir=tests/regress --dbname=ulak_test

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ All settings use the `ulak.` prefix.
 | `ulak.workers` | `4` | Number of background workers |
 | `ulak.database` | unset | Database workers connect to |
 | `ulak.poll_interval` | `500ms` | Queue polling interval |
+| `ulak.wake_notify` | `off` | Also `NOTIFY ulak_new_msg` for external workers that `LISTEN`; in-database workers are woken through shared memory |
 | `ulak.batch_size` | `200` | Messages claimed per cycle |
 | `ulak.default_max_retries` | `10` | Default retry budget |
 | `ulak.retry_base_delay` | `10s` | Retry backoff base |

--- a/sql/ulak--0.1.2--0.2.0.sql
+++ b/sql/ulak--0.1.2--0.2.0.sql
@@ -1,0 +1,339 @@
+-- ulak 0.1.2 -> 0.2.0 upgrade migration
+-- Workers are woken through shared memory at commit instead of a NOTIFY per
+-- insert (src/wake.c): adds ulak._wake_workers() and routes the queue trigger,
+-- send_with_options(), send_batch*(), publish*() through it.
+-- Function bodies are copied verbatim from sql/ulak.sql.
+
+CREATE OR REPLACE FUNCTION ulak._wake_workers(
+    p_id bigint,
+    p_ordering_key text
+) RETURNS void
+LANGUAGE c
+VOLATILE PARALLEL UNSAFE
+AS 'ulak', 'ulak_wake_workers_sql';
+
+CREATE OR REPLACE FUNCTION ulak.notify_new_message()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Skip if suppressed (bulk COPY, or a caller that wakes the exact partition itself)
+    IF current_setting('ulak.suppress_notify', true) = 'on' THEN
+        RETURN NULL;
+    END IF;
+    -- Statement-level trigger: the ids are unknown here, wake every worker
+    PERFORM ulak._wake_workers(NULL, NULL);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ulak.send_with_options(
+    p_endpoint_name text,
+    p_payload jsonb,
+    p_priority smallint DEFAULT 0,
+    p_scheduled_at timestamptz DEFAULT NULL,
+    p_idempotency_key text DEFAULT NULL,
+    p_correlation_id uuid DEFAULT NULL,
+    p_expires_at timestamptz DEFAULT NULL,
+    p_ordering_key text DEFAULT NULL
+) RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, ulak
+AS $$
+DECLARE
+    v_endpoint_id bigint;
+    v_message_id bigint;
+    v_payload_hash text;
+    v_existing_hash text;
+BEGIN
+    -- Backpressure check
+    PERFORM ulak._check_backpressure();
+
+    -- Validate endpoint exists and is enabled
+    SELECT id INTO v_endpoint_id
+    FROM ulak.endpoints
+    WHERE name = p_endpoint_name AND enabled = true;
+
+    IF v_endpoint_id IS NULL THEN
+        RAISE EXCEPTION 'Endpoint ''%'' does not exist or is disabled', p_endpoint_name;
+    END IF;
+
+    -- Validate priority range
+    IF p_priority < 0 OR p_priority > 10 THEN
+        RAISE EXCEPTION 'Priority must be between 0 and 10, got %', p_priority;
+    END IF;
+
+    -- Compute payload hash when idempotency key is provided
+    v_payload_hash := CASE WHEN p_idempotency_key IS NOT NULL
+                          THEN md5(p_payload::text) ELSE NULL END;
+
+    -- Insert message with all options. The statement trigger would wake every
+    -- worker; suppress it and wake the one partition this row hashes to.
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
+    INSERT INTO ulak.queue (
+        endpoint_id, payload, status, retry_count, next_retry_at,
+        priority, scheduled_at, idempotency_key, correlation_id, expires_at,
+        payload_hash, ordering_key
+    )
+    VALUES (
+        v_endpoint_id, p_payload, 'pending', 0,
+        COALESCE(p_scheduled_at, NOW()),
+        p_priority, p_scheduled_at, p_idempotency_key, p_correlation_id, p_expires_at,
+        v_payload_hash, p_ordering_key
+    )
+    RETURNING id INTO v_message_id;
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    PERFORM ulak._wake_workers(v_message_id, p_ordering_key);
+
+    RETURN v_message_id;
+EXCEPTION
+    WHEN unique_violation THEN
+        -- Idempotency key collision - check payload hash match
+        SELECT id, payload_hash INTO v_message_id, v_existing_hash
+        FROM ulak.queue
+        WHERE idempotency_key = p_idempotency_key;
+
+        IF v_existing_hash IS DISTINCT FROM v_payload_hash THEN
+            RAISE EXCEPTION 'Idempotency key ''%'' conflict: same key with different payload', p_idempotency_key;
+        END IF;
+
+        RETURN v_message_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ulak.send_batch(
+    p_endpoint_name text,
+    p_payloads jsonb[]
+) RETURNS bigint[]
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, ulak
+AS $$
+DECLARE
+    v_endpoint_id bigint;
+    v_ids bigint[];
+BEGIN
+    -- Backpressure check
+    PERFORM ulak._check_backpressure();
+
+    -- Validate endpoint exists and is enabled
+    SELECT id INTO v_endpoint_id
+    FROM ulak.endpoints
+    WHERE name = p_endpoint_name AND enabled = true;
+
+    IF v_endpoint_id IS NULL THEN
+        RAISE EXCEPTION 'Endpoint ''%'' does not exist or is disabled', p_endpoint_name;
+    END IF;
+
+    -- Suppress the trigger during bulk insert (workers are woken once at the end)
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
+
+    -- Bulk insert all payloads in a single INSERT using unnest
+    WITH inserted AS (
+        INSERT INTO ulak.queue (endpoint_id, payload, status, next_retry_at, created_at, updated_at)
+        SELECT v_endpoint_id, p, 'pending', NOW(), NOW(), NOW()
+        FROM unnest(p_payloads) AS p
+        RETURNING id
+    )
+    SELECT array_agg(id) INTO v_ids FROM inserted;
+
+    -- Re-enable the trigger and wake the workers once for the whole batch
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    PERFORM ulak._wake_workers(NULL, NULL);
+
+    RETURN v_ids;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ulak.send_batch_with_priority(
+    p_endpoint_name text,
+    p_payloads jsonb[],
+    p_priority smallint DEFAULT 0
+) RETURNS bigint[]
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, ulak
+AS $$
+DECLARE
+    v_endpoint_id bigint;
+    v_ids bigint[];
+BEGIN
+    -- Backpressure check
+    PERFORM ulak._check_backpressure();
+
+    SELECT id INTO v_endpoint_id
+    FROM ulak.endpoints
+    WHERE name = p_endpoint_name AND enabled = true;
+
+    IF v_endpoint_id IS NULL THEN
+        RAISE EXCEPTION 'Endpoint ''%'' does not exist or is disabled', p_endpoint_name;
+    END IF;
+
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
+
+    WITH inserted AS (
+        INSERT INTO ulak.queue (endpoint_id, payload, status, priority, next_retry_at, created_at, updated_at)
+        SELECT v_endpoint_id, p, 'pending', p_priority, NOW(), NOW(), NOW()
+        FROM unnest(p_payloads) AS p
+        RETURNING id
+    )
+    SELECT array_agg(id) INTO v_ids FROM inserted;
+
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    PERFORM ulak._wake_workers(NULL, NULL);
+
+    RETURN v_ids;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ulak.publish(
+    p_event_type text,
+    p_payload jsonb
+) RETURNS integer
+LANGUAGE plpgsql VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, ulak
+AS $$
+DECLARE
+    v_event_type_id bigint;
+    v_count integer;
+    v_projected_count bigint;
+BEGIN
+    SELECT id INTO v_event_type_id FROM ulak.event_types WHERE name = p_event_type;
+    IF v_event_type_id IS NULL THEN
+        RAISE EXCEPTION 'Event type ''%'' does not exist', p_event_type;
+    END IF;
+
+    SELECT count(*) INTO v_projected_count
+    FROM ulak.subscriptions s
+    JOIN ulak.endpoints e ON e.id = s.endpoint_id
+    WHERE s.event_type_id = v_event_type_id
+      AND s.enabled = true
+      AND e.enabled = true
+      AND (s.filter IS NULL OR p_payload @> s.filter);
+
+    -- Backpressure check with exact projected fan-out row count
+    PERFORM ulak._check_backpressure(v_projected_count);
+
+    -- Suppress per-row NOTIFY during fan-out (same pattern as send_batch)
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
+
+    -- Fan-out: INSERT...SELECT from active subscriptions for enabled endpoints
+    WITH inserted AS (
+        INSERT INTO ulak.queue (endpoint_id, payload, status, next_retry_at, created_at, updated_at)
+        SELECT s.endpoint_id, p_payload, 'pending', NOW(), NOW(), NOW()
+        FROM ulak.subscriptions s
+        JOIN ulak.endpoints e ON e.id = s.endpoint_id
+        WHERE s.event_type_id = v_event_type_id
+          AND s.enabled = true
+          AND e.enabled = true
+          AND (s.filter IS NULL OR p_payload @> s.filter)
+        RETURNING id
+    )
+    SELECT count(*) INTO v_count FROM inserted;
+
+    -- Re-enable the trigger and wake the workers once for the entire fan-out
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    IF v_count > 0 THEN
+        PERFORM ulak._wake_workers(NULL, NULL);
+    END IF;
+
+    RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ulak.publish_batch(
+    p_events jsonb
+) RETURNS integer
+LANGUAGE plpgsql VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, ulak
+AS $$
+DECLARE
+    v_event record;
+    v_event_type_id bigint;
+    v_total integer := 0;
+    v_count integer;
+    v_projected_count bigint;
+    v_missing_event_type text;
+BEGIN
+    WITH batch_events AS (
+        SELECT e->>'event_type' AS event_type
+        FROM jsonb_array_elements(p_events) AS e
+    )
+    SELECT be.event_type INTO v_missing_event_type
+    FROM batch_events be
+    LEFT JOIN ulak.event_types et ON et.name = be.event_type
+    WHERE et.id IS NULL
+    LIMIT 1;
+
+    IF v_missing_event_type IS NOT NULL THEN
+        RAISE EXCEPTION 'Event type ''%'' does not exist', v_missing_event_type;
+    END IF;
+
+    WITH batch_events AS (
+        SELECT e->>'event_type' AS event_type, e->'payload' AS payload
+        FROM jsonb_array_elements(p_events) AS e
+    )
+    SELECT COALESCE(count(*), 0) INTO v_projected_count
+    FROM batch_events be
+    JOIN ulak.event_types et ON et.name = be.event_type
+    JOIN ulak.subscriptions s ON s.event_type_id = et.id
+    JOIN ulak.endpoints ep ON ep.id = s.endpoint_id
+    WHERE s.enabled = true
+      AND ep.enabled = true
+      AND (s.filter IS NULL OR be.payload @> s.filter);
+
+    -- Backpressure check with exact projected fan-out row count for the entire batch
+    PERFORM ulak._check_backpressure(v_projected_count);
+
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
+
+    FOR v_event IN
+        SELECT e->>'event_type' AS event_type, e->'payload' AS payload
+        FROM jsonb_array_elements(p_events) AS e
+    LOOP
+        SELECT id INTO v_event_type_id FROM ulak.event_types WHERE name = v_event.event_type;
+        IF v_event_type_id IS NULL THEN
+            RAISE EXCEPTION 'Event type ''%'' does not exist', v_event.event_type;
+        END IF;
+
+        WITH inserted AS (
+            INSERT INTO ulak.queue (endpoint_id, payload, status, next_retry_at, created_at, updated_at)
+            SELECT s.endpoint_id, v_event.payload, 'pending', NOW(), NOW(), NOW()
+            FROM ulak.subscriptions s
+            JOIN ulak.endpoints e ON e.id = s.endpoint_id
+            WHERE s.event_type_id = v_event_type_id
+              AND s.enabled = true
+              AND e.enabled = true
+              AND (s.filter IS NULL OR v_event.payload @> s.filter)
+            RETURNING id
+        )
+        SELECT count(*) INTO v_count FROM inserted;
+        v_total := v_total + v_count;
+    END LOOP;
+
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    IF v_total > 0 THEN
+        PERFORM ulak._wake_workers(NULL, NULL);
+    END IF;
+
+    RETURN v_total;
+END;
+$$;
+
+COMMENT ON FUNCTION ulak._wake_workers(bigint, text) IS
+'Internal: wake the delivery worker(s) responsible for a queued row once the current transaction commits.
+The extension sets worker latches through shared memory (no NOTIFY lock); NULL id wakes every worker.';
+
+COMMENT ON FUNCTION ulak.send_batch(text, jsonb[]) IS
+'High-throughput batch send: inserts multiple messages in a single SQL statement.
+Uses unnest pattern for 10-15x higher throughput than individual send() calls.
+Workers are woken once for the entire batch.
+Example: SELECT ulak.send_batch(''webhook'', ARRAY[''{...}''::jsonb, ''{...}''::jsonb])';
+
+-- New functions start with EXECUTE for PUBLIC; the fresh schema revokes it
+REVOKE ALL ON FUNCTION ulak._wake_workers(bigint, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION ulak._wake_workers(bigint, text) TO ulak_admin;

--- a/sql/ulak.sql
+++ b/sql/ulak.sql
@@ -475,16 +475,34 @@ CREATE TRIGGER update_subscriptions_updated_at
     BEFORE UPDATE ON ulak.subscriptions
     FOR EACH ROW EXECUTE FUNCTION ulak.update_updated_at();
 
--- Notify trigger for new messages
+-- Wake-up of delivery workers. The extension marks the partition the row
+-- belongs to and sets that worker's latch from a commit callback (src/wake.c);
+-- it does not NOTIFY unless ulak.wake_notify is on (external workers that can
+-- only LISTEN get a NOTIFY 'ulak_new_msg' throttled by ulak.notify_throttle_ms).
+-- p_id NULL means "rows with unknown ids were inserted": wake every worker.
+CREATE OR REPLACE FUNCTION ulak._wake_workers(
+    p_id bigint,
+    p_ordering_key text
+) RETURNS void
+LANGUAGE c
+VOLATILE PARALLEL UNSAFE
+AS 'ulak', 'ulak_wake_workers_sql';
+
+COMMENT ON FUNCTION ulak._wake_workers(bigint, text) IS
+'Internal: wake the delivery worker(s) responsible for a queued row once the current transaction commits.
+The extension sets worker latches through shared memory (no NOTIFY lock); NULL id wakes every worker.';
+
+-- Wake trigger for new messages
 -- Uses current_setting to allow suppression during batch operations
 CREATE OR REPLACE FUNCTION ulak.notify_new_message()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- Skip NOTIFY if suppressed (e.g., during bulk COPY or send_batch)
+    -- Skip if suppressed (bulk COPY, or a caller that wakes the exact partition itself)
     IF current_setting('ulak.suppress_notify', true) = 'on' THEN
         RETURN NULL;
     END IF;
-    PERFORM pg_notify('ulak_new_msg', '');
+    -- Statement-level trigger: the ids are unknown here, wake every worker
+    PERFORM ulak._wake_workers(NULL, NULL);
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -830,7 +848,9 @@ BEGIN
     v_payload_hash := CASE WHEN p_idempotency_key IS NOT NULL
                           THEN md5(p_payload::text) ELSE NULL END;
 
-    -- Insert message with all options
+    -- Insert message with all options. The statement trigger would wake every
+    -- worker; suppress it and wake the one partition this row hashes to.
+    PERFORM set_config('ulak.suppress_notify', 'on', true);
     INSERT INTO ulak.queue (
         endpoint_id, payload, status, retry_count, next_retry_at,
         priority, scheduled_at, idempotency_key, correlation_id, expires_at,
@@ -843,6 +863,8 @@ BEGIN
         v_payload_hash, p_ordering_key
     )
     RETURNING id INTO v_message_id;
+    PERFORM set_config('ulak.suppress_notify', 'off', true);
+    PERFORM ulak._wake_workers(v_message_id, p_ordering_key);
 
     RETURN v_message_id;
 EXCEPTION
@@ -899,7 +921,7 @@ BEGIN
         RAISE EXCEPTION 'Endpoint ''%'' does not exist or is disabled', p_endpoint_name;
     END IF;
 
-    -- Suppress trigger NOTIFY during bulk insert (we do our own at the end)
+    -- Suppress the trigger during bulk insert (workers are woken once at the end)
     PERFORM set_config('ulak.suppress_notify', 'on', true);
 
     -- Bulk insert all payloads in a single INSERT using unnest
@@ -911,9 +933,9 @@ BEGIN
     )
     SELECT array_agg(id) INTO v_ids FROM inserted;
 
-    -- Re-enable trigger NOTIFY and send single notification for batch
+    -- Re-enable the trigger and wake the workers once for the whole batch
     PERFORM set_config('ulak.suppress_notify', 'off', true);
-    PERFORM pg_notify('ulak_new_msg', '');
+    PERFORM ulak._wake_workers(NULL, NULL);
 
     RETURN v_ids;
 END;
@@ -922,7 +944,7 @@ $$;
 COMMENT ON FUNCTION ulak.send_batch(text, jsonb[]) IS
 'High-throughput batch send: inserts multiple messages in a single SQL statement.
 Uses unnest pattern for 10-15x higher throughput than individual send() calls.
-Single NOTIFY is sent for the entire batch.
+Workers are woken once for the entire batch.
 Example: SELECT ulak.send_batch(''webhook'', ARRAY[''{...}''::jsonb, ''{...}''::jsonb])';
 
 -- Batch send with priority support
@@ -962,7 +984,7 @@ BEGIN
     SELECT array_agg(id) INTO v_ids FROM inserted;
 
     PERFORM set_config('ulak.suppress_notify', 'off', true);
-    PERFORM pg_notify('ulak_new_msg', '');
+    PERFORM ulak._wake_workers(NULL, NULL);
 
     RETURN v_ids;
 END;
@@ -1633,10 +1655,10 @@ BEGIN
     )
     SELECT count(*) INTO v_count FROM inserted;
 
-    -- Re-enable NOTIFY and send single notification for entire fan-out
+    -- Re-enable the trigger and wake the workers once for the entire fan-out
     PERFORM set_config('ulak.suppress_notify', 'off', true);
     IF v_count > 0 THEN
-        PERFORM pg_notify('ulak_new_msg', '');
+        PERFORM ulak._wake_workers(NULL, NULL);
     END IF;
 
     RETURN v_count;
@@ -1716,7 +1738,7 @@ BEGIN
 
     PERFORM set_config('ulak.suppress_notify', 'off', true);
     IF v_total > 0 THEN
-        PERFORM pg_notify('ulak_new_msg', '');
+        PERFORM ulak._wake_workers(NULL, NULL);
     END IF;
 
     RETURN v_total;
@@ -2176,7 +2198,8 @@ GRANT EXECUTE ON FUNCTION ulak.cleanup_event_log() TO ulak_admin;
 GRANT EXECUTE ON FUNCTION ulak.cleanup_dlq() TO ulak_admin;
 GRANT EXECUTE ON FUNCTION ulak._check_backpressure(bigint) TO ulak_admin;
 GRANT EXECUTE ON FUNCTION ulak._active_queue_count(bigint) TO ulak_admin;
--- NOTE: _check_backpressure/_active_queue_count are internal functions called
+GRANT EXECUTE ON FUNCTION ulak._wake_workers(bigint, text) TO ulak_admin;
+-- NOTE: _check_backpressure/_active_queue_count/_wake_workers are internal functions called
 -- by the SECURITY DEFINER send/publish APIs. No direct GRANT to ulak_application needed.
 GRANT EXECUTE ON FUNCTION ulak.archive_single_to_dlq(bigint) TO ulak_admin;
 GRANT EXECUTE ON FUNCTION ulak.archive_completed_messages(integer, integer) TO ulak_admin;

--- a/src/config/guc.c
+++ b/src/config/guc.c
@@ -25,6 +25,8 @@ int ulak_batch_size = 200;
 int ulak_log_level = LOG_LEVEL_WARNING;
 int ulak_default_max_retries = 10;
 int ulak_stale_recovery_timeout = 300;
+bool ulak_wake_notify = false;
+int ulak_notify_throttle_ms = 100;
 
 /** Retry Configuration */
 int ulak_retry_base_delay = 10;
@@ -198,6 +200,19 @@ void config_init_guc_variables(void) {
     DefineCustomIntVariable("ulak.batch_size", "Number of messages to process per batch",
                             "Number of messages to process in each batch", &ulak_batch_size, 200, 1,
                             1000, PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
+
+    /* Workers are woken through shared memory at commit (wake.c); NOTIFY is
+     * only for external worker processes that share the queue and LISTEN. */
+    DefineCustomBoolVariable(
+        "ulak.wake_notify", "Also NOTIFY ulak_new_msg when messages are queued",
+        "Enable when external worker processes share the queue via LISTEN; "
+        "in-database workers are woken through shared memory.",
+        &ulak_wake_notify, false, PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
+
+    DefineCustomIntVariable(
+        "ulak.notify_throttle_ms", "Minimum gap between NOTIFYs from one session (ms)",
+        "Applies when ulak.wake_notify is on; 0 notifies on every commit", &ulak_notify_throttle_ms,
+        100, 0, 60000, PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
 
     DefineCustomEnumVariable("ulak.log_level", "Log level for ulak extension",
                              "Logging level: error, warning, info, debug", &ulak_log_level,

--- a/src/config/guc.h
+++ b/src/config/guc.h
@@ -21,6 +21,8 @@ extern int ulak_batch_size;
 extern int ulak_default_max_retries;
 extern int ulak_log_level;
 extern int ulak_stale_recovery_timeout;
+extern bool ulak_wake_notify;
+extern int ulak_notify_throttle_ms;
 
 /* Worker & Core Configuration */
 extern char *ulak_database;

--- a/src/dispatchers/redis/redis_connection.c
+++ b/src/dispatchers/redis/redis_connection.c
@@ -8,7 +8,14 @@
 
 #include "redis_internal.h"
 
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <time.h>
 
 #include "postgres.h"
@@ -47,6 +54,173 @@ bool redis_is_permanent_error(const char *error_str) {
     return false;
 }
 
+/* ------------------------------------------------------------------------
+ * Bounded host resolution
+ *
+ * hiredis resolves the host name with a blocking getaddrinfo() before it
+ * applies the connect timeout to connect() [source: redis/hiredis net.c,
+ * _redisContextConnectTcp, via deepwiki]. A broken DNS record therefore
+ * stalled the worker for the resolver's own retry schedule (8-15 s in
+ * Docker) no matter what connect_timeout said. We resolve the name on a
+ * helper thread, wait at most connect_timeout for it, hand hiredis the
+ * numeric address and cache it for REDIS_RESOLVE_TTL_SEC.
+ *
+ * The thread only calls getaddrinfo/inet_ntop and touches malloc'd memory
+ * (palloc is not thread-safe and the batch context may be gone by the time
+ * an abandoned lookup finishes). If the wait times out the job is marked
+ * abandoned and the thread frees it itself when the lookup returns.
+ * ------------------------------------------------------------------------ */
+
+#define REDIS_RESOLVE_TTL_SEC 60
+
+typedef struct RedisResolveJob {
+    pthread_mutex_t lock;
+    pthread_cond_t done_cv;
+    char *host;     /* malloc'd copy of the name to resolve */
+    bool done;      /* lookup finished, result fields valid */
+    bool abandoned; /* caller stopped waiting; thread owns the job */
+    int gai_rc;     /* getaddrinfo() return code */
+    char ip[64];    /* numeric address, '\0' when none found */
+} RedisResolveJob;
+
+static void redis_resolve_job_free(RedisResolveJob *job) {
+    pthread_mutex_destroy(&job->lock);
+    pthread_cond_destroy(&job->done_cv);
+    free(job->host);
+    free(job);
+}
+
+static void *redis_resolve_thread(void *arg) {
+    RedisResolveJob *job = (RedisResolveJob *)arg;
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *ai;
+    char ip[64] = "";
+    int rc;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    rc = getaddrinfo(job->host, NULL, &hints, &res);
+    if (rc == 0 && res != NULL) {
+        /* Prefer IPv4, then the first IPv6 address */
+        for (ai = res; ai != NULL; ai = ai->ai_next) {
+            if (ai->ai_family == AF_INET) {
+                inet_ntop(AF_INET, &((struct sockaddr_in *)ai->ai_addr)->sin_addr, ip, sizeof(ip));
+                break;
+            }
+        }
+        if (ip[0] == '\0') {
+            for (ai = res; ai != NULL; ai = ai->ai_next) {
+                if (ai->ai_family == AF_INET6) {
+                    inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr, ip,
+                              sizeof(ip));
+                    break;
+                }
+            }
+        }
+        freeaddrinfo(res);
+    }
+
+    pthread_mutex_lock(&job->lock);
+    if (job->abandoned) {
+        pthread_mutex_unlock(&job->lock);
+        redis_resolve_job_free(job);
+        return NULL;
+    }
+    job->gai_rc = rc;
+    strlcpy(job->ip, ip, sizeof(job->ip));
+    job->done = true;
+    pthread_cond_signal(&job->done_cv);
+    pthread_mutex_unlock(&job->lock);
+    return NULL;
+}
+
+/**
+ * @brief Resolve @p host to a numeric address, waiting at most @p timeout_sec.
+ *
+ * @return true and fills @p ip_out; false with a retryable @p error_msg on
+ *         timeout, resolver failure or thread creation failure.
+ */
+static bool redis_resolve_host_bounded(const char *host, int timeout_sec, char *ip_out,
+                                       size_t ip_len, char **error_msg) {
+    RedisResolveJob *job;
+    pthread_t tid;
+    pthread_attr_t attr;
+    struct timespec deadline;
+    struct in_addr a4;
+    struct in6_addr a6;
+    sigset_t block_all;
+    sigset_t saved_mask;
+    bool ok = false;
+    int rc;
+
+    /* Numeric address: nothing to resolve */
+    if (inet_pton(AF_INET, host, &a4) == 1 || inet_pton(AF_INET6, host, &a6) == 1) {
+        strlcpy(ip_out, host, ip_len);
+        return true;
+    }
+
+    job = (RedisResolveJob *)calloc(1, sizeof(RedisResolveJob));
+    if (job == NULL || (job->host = strdup(host)) == NULL) {
+        free(job);
+        if (error_msg)
+            *error_msg = pstrdup(ERROR_PREFIX_RETRYABLE " Redis resolver: out of memory");
+        return false;
+    }
+    pthread_mutex_init(&job->lock, NULL);
+    pthread_cond_init(&job->done_cv, NULL);
+
+    /* The helper must never receive the backend's signals (SIGTERM, SIGHUP,
+     * SIGURG for the latch): a new thread inherits the creator's mask, so
+     * block everything while creating it and restore our own mask after. */
+    sigfillset(&block_all);
+    pthread_sigmask(SIG_BLOCK, &block_all, &saved_mask);
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    rc = pthread_create(&tid, &attr, redis_resolve_thread, job);
+    pthread_attr_destroy(&attr);
+    pthread_sigmask(SIG_SETMASK, &saved_mask, NULL);
+    if (rc != 0) {
+        redis_resolve_job_free(job);
+        if (error_msg)
+            *error_msg =
+                psprintf(ERROR_PREFIX_RETRYABLE " Redis resolver thread failed: %s", strerror(rc));
+        return false;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += timeout_sec > 0 ? timeout_sec : 1;
+
+    pthread_mutex_lock(&job->lock);
+    while (!job->done) {
+        rc = pthread_cond_timedwait(&job->done_cv, &job->lock, &deadline);
+        if (rc == ETIMEDOUT)
+            break;
+    }
+    if (!job->done) {
+        /* Give up; the thread frees the job when getaddrinfo returns */
+        job->abandoned = true;
+        pthread_mutex_unlock(&job->lock);
+        if (error_msg)
+            *error_msg =
+                psprintf(ERROR_PREFIX_RETRYABLE " Redis DNS resolution of %s timed out after %d s",
+                         host, timeout_sec);
+        return false;
+    }
+    if (job->gai_rc == 0 && job->ip[0] != '\0') {
+        strlcpy(ip_out, job->ip, ip_len);
+        ok = true;
+    } else if (error_msg) {
+        *error_msg = psprintf(ERROR_PREFIX_RETRYABLE " Redis DNS resolution of %s failed: %s", host,
+                              job->gai_rc != 0 ? gai_strerror(job->gai_rc) : "no address");
+    }
+    pthread_mutex_unlock(&job->lock);
+    redis_resolve_job_free(job);
+    return ok;
+}
+
 /**
  * @brief Connect to Redis server (internal).
  *
@@ -59,12 +233,30 @@ bool redis_is_permanent_error(const char *error_str) {
  */
 bool redis_connect_internal(RedisDispatcher *redis, char **error_msg) {
     struct timeval timeout;
+    const char *connect_host;
 
     timeout.tv_sec = redis->connect_timeout;
     timeout.tv_usec = 0;
 
     /* Disconnect existing connection if any */
     redis_disconnect_internal(redis);
+
+    /* Resolve the host ourselves (bounded, cached) and hand hiredis the address */
+    if (redis->resolved_ip[0] == '\0' || time(NULL) - redis->resolved_at >= REDIS_RESOLVE_TTL_SEC) {
+        char ip[sizeof(redis->resolved_ip)];
+
+        if (!redis_resolve_host_bounded(redis->host, redis->connect_timeout, ip, sizeof(ip),
+                                        error_msg)) {
+            redis->resolved_ip[0] = '\0';
+            ulak_log("error", "Failed to resolve Redis host %s: %s", redis->host,
+                     error_msg && *error_msg ? *error_msg : "unknown error");
+            return false;
+        }
+        strlcpy(redis->resolved_ip, ip, sizeof(redis->resolved_ip));
+        redis->resolved_at = time(NULL);
+        ulak_log("debug", "Resolved Redis host %s to %s", redis->host, redis->resolved_ip);
+    }
+    connect_host = redis->resolved_ip;
 
     if (redis->tls) {
         /* TLS connection */
@@ -79,7 +271,7 @@ bool redis_connect_internal(RedisDispatcher *redis, char **error_msg) {
         redis->ssl_context = ssl_ctx;
 
         /* Create TCP connection first */
-        redis->context = redisConnectWithTimeout(redis->host, redis->port, timeout);
+        redis->context = redisConnectWithTimeout(connect_host, redis->port, timeout);
 
         if (!redis->context || redis->context->err) {
             const char *err = redis->context ? redis->context->errstr : "Connection failed";
@@ -94,6 +286,7 @@ bool redis_connect_internal(RedisDispatcher *redis, char **error_msg) {
             }
             redis_tls_cleanup(redis->ssl_context);
             redis->ssl_context = NULL;
+            redis->resolved_ip[0] = '\0';
             return false;
         }
 
@@ -109,7 +302,7 @@ bool redis_connect_internal(RedisDispatcher *redis, char **error_msg) {
         ulak_log("debug", "Redis TLS connection established to %s:%d", redis->host, redis->port);
     } else {
         /* Plain TCP connection */
-        redis->context = redisConnectWithTimeout(redis->host, redis->port, timeout);
+        redis->context = redisConnectWithTimeout(connect_host, redis->port, timeout);
 
         if (!redis->context || redis->context->err) {
             const char *err = redis->context ? redis->context->errstr : "Connection failed";
@@ -122,6 +315,7 @@ bool redis_connect_internal(RedisDispatcher *redis, char **error_msg) {
                 redisFree(redis->context);
                 redis->context = NULL;
             }
+            redis->resolved_ip[0] = '\0';
             return false;
         }
 

--- a/src/dispatchers/redis/redis_dispatcher.h
+++ b/src/dispatchers/redis/redis_dispatcher.h
@@ -97,6 +97,8 @@ typedef struct {
     /** @name Runtime connection state */
     /** @{ */
     redisContext *context;        /**< Active hiredis connection (NULL if disconnected). */
+    char resolved_ip[64];         /**< Cached numeric address of host ('' = not resolved). */
+    time_t resolved_at;           /**< When resolved_ip was obtained (60 s TTL). */
     redisSSLContext *ssl_context; /**< TLS context (NULL if TLS disabled). */
     /** @} */
 

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -207,6 +207,7 @@ void ulak_register_database(const char *dbname, Oid dboid) {
             SpinLockInit(&ulak_shmem->databases[i].metrics_mutex);
             for (j = 0; j < ULAK_MAX_WORKERS; j++) {
                 ulak_shmem->databases[i].worker_pids[j] = 0;
+                ulak_shmem->databases[i].worker_latches[j] = NULL;
                 ulak_shmem->databases[i].worker_started_at[j] = 0;
                 ulak_shmem->databases[i].messages_processed[j] = 0;
                 ulak_shmem->databases[i].error_count[j] = 0;
@@ -287,9 +288,10 @@ int ulak_get_registered_databases(UlakDatabaseEntry *entries, int max_entries) {
  * @param dboid     Database OID.
  * @param pid       Worker process ID.
  * @param worker_id Slot index (0 to ULAK_MAX_WORKERS-1).
+ * @param latch     The worker's process latch (MyLatch), set by senders at commit.
  * @return 0 on success, -1 on error.
  */
-int ulak_add_worker_pid(Oid dboid, pid_t pid, int worker_id) {
+int ulak_add_worker_pid(Oid dboid, pid_t pid, int worker_id, Latch *latch) {
     int i;
     int result = -1;
 
@@ -312,6 +314,7 @@ int ulak_add_worker_pid(Oid dboid, pid_t pid, int worker_id) {
                      worker_id, ulak_shmem->databases[i].worker_pids[worker_id], dboid);
             } else {
                 ulak_shmem->databases[i].worker_pids[worker_id] = pid;
+                ulak_shmem->databases[i].worker_latches[worker_id] = latch;
                 ulak_shmem->databases[i].worker_started_at[worker_id] = GetCurrentTimestamp();
                 ulak_shmem->databases[i].active_workers++;
                 result = 0;
@@ -350,6 +353,7 @@ void ulak_remove_worker_pid(Oid dboid, pid_t pid) {
             for (j = 0; j < ULAK_MAX_WORKERS; j++) {
                 if (ulak_shmem->databases[i].worker_pids[j] == pid) {
                     ulak_shmem->databases[i].worker_pids[j] = 0;
+                    ulak_shmem->databases[i].worker_latches[j] = NULL;
                     if (ulak_shmem->databases[i].active_workers > 0)
                         ulak_shmem->databases[i].active_workers--;
                     elog(LOG, "[ulak] Worker PID %d removed from slot %d for database OID %u", pid,
@@ -368,6 +372,42 @@ void ulak_remove_worker_pid(Oid dboid, pid_t pid) {
     }
 
     LWLockRelease(ulak_shmem->lock);
+}
+
+/**
+ * @brief Set the latches of the workers named in @p mask (bit = worker_id).
+ *
+ * Runs from a transaction-commit callback in every sending backend, so it
+ * deliberately takes no lock: the fields it reads are pointer/int sized and
+ * a stale value only costs a spurious SetLatch, which is harmless — PGPROC
+ * latches live in shared memory for the life of the cluster.
+ *
+ * @param dboid Database whose workers to wake.
+ * @param mask  Worker slots to wake (bit i = worker_id i).
+ */
+void ulak_wake_workers(Oid dboid, uint32 mask) {
+    int i, j;
+
+    if (ulak_shmem == NULL || mask == 0)
+        return;
+
+    for (i = 0; i < ULAK_MAX_DATABASES; i++) {
+        UlakDatabaseEntry *entry = &ulak_shmem->databases[i];
+
+        if (!entry->active || entry->dboid != dboid)
+            continue;
+
+        for (j = 0; j < ULAK_MAX_WORKERS && j < 32; j++) {
+            Latch *latch;
+
+            if ((mask & (1u << j)) == 0)
+                continue;
+            latch = entry->worker_latches[j];
+            if (latch != NULL && entry->worker_pids[j] != 0)
+                SetLatch(latch);
+        }
+        return;
+    }
 }
 
 /**

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -12,6 +12,7 @@
 #define ULAK_SHMEM_H
 
 #include "postgres.h"
+#include "storage/latch.h"
 #include "storage/lwlock.h"
 #include "storage/spin.h"
 #include "utils/timestamp.h"
@@ -47,13 +48,14 @@ typedef struct RateLimitShmemBucket {
  * The entry is deactivated automatically when its last worker exits.
  */
 typedef struct UlakDatabaseEntry {
-    Oid dboid;                                       /* Database OID */
-    char dbname[NAMEDATALEN];                        /* Database name */
-    bool active;                                     /* Is this entry in use? */
-    int target_workers;                              /* Target worker count from GUC */
-    int active_workers;                              /* Number of currently running workers */
-    pid_t worker_pids[ULAK_MAX_WORKERS];             /* PIDs of workers (0 if slot empty) */
-    TimestampTz registered_at;                       /* When database was registered */
+    Oid dboid;                               /* Database OID */
+    char dbname[NAMEDATALEN];                /* Database name */
+    bool active;                             /* Is this entry in use? */
+    int target_workers;                      /* Target worker count from GUC */
+    int active_workers;                      /* Number of currently running workers */
+    pid_t worker_pids[ULAK_MAX_WORKERS];     /* PIDs of workers (0 if slot empty) */
+    Latch *worker_latches[ULAK_MAX_WORKERS]; /* &MyProc->procLatch of each worker (NULL if empty) */
+    TimestampTz registered_at;               /* When database was registered */
     TimestampTz worker_started_at[ULAK_MAX_WORKERS]; /* When each worker started */
 
     /* Worker metrics and error tracking (protected by metrics_mutex) */
@@ -117,9 +119,10 @@ extern Size ulak_shmem_size(void);
 /*
  * Worker tracking functions.
  */
-extern int ulak_add_worker_pid(Oid dboid, pid_t pid, int worker_id);
+extern int ulak_add_worker_pid(Oid dboid, pid_t pid, int worker_id, Latch *latch);
 extern void ulak_remove_worker_pid(Oid dboid, pid_t pid);
 extern void ulak_set_target_workers(Oid dboid, int count);
+extern void ulak_wake_workers(Oid dboid, uint32 mask);
 extern void ulak_update_worker_metrics(Oid dboid, int worker_id, int64 processed, int32 errors,
                                        const char *error_msg);
 extern void ulak_update_worker_activity(Oid dboid, int worker_id);

--- a/src/ulak.c
+++ b/src/ulak.c
@@ -29,6 +29,7 @@ PG_MODULE_MAGIC;
 #include "shmem.h"
 #include "utils/json_utils.h"
 #include "utils/logging.h"
+#include "wake.h"
 
 /* SRF and system includes */
 #include "catalog/pg_type.h"
@@ -246,21 +247,35 @@ Datum ulak_send(PG_FUNCTION_ARGS) {
     endpoint_id =
         DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull));
 
-    /* Insert message into queue (fully parameterized) */
+    /*
+     * Insert message into queue (fully parameterized). The statement trigger
+     * would wake every worker; we know the row id, so skip it and mark the
+     * one partition the row hashes to (wake.c sets its latch at commit).
+     */
+    ulak_wake_set_skip_trigger(true);
     ret = SPI_execute_with_args(
         "INSERT INTO ulak.queue "
         "(endpoint_id, payload, status, retry_count, next_retry_at) "
-        "VALUES ($1, $2, 'pending', 0, NOW())",
+        "VALUES ($1, $2, 'pending', 0, NOW()) RETURNING id",
         2, (Oid[]){INT8OID, JSONBOID},
         (Datum[]){Int64GetDatum(endpoint_id), JsonbPGetDatum(payload_jsonb)}, NULL, false, 0);
-    if (ret != SPI_OK_INSERT)
+    ulak_wake_set_skip_trigger(false);
+    if (ret != SPI_OK_INSERT_RETURNING || SPI_processed != 1 || SPI_tuptable == NULL)
         ereport(ERROR,
                 (errcode(ERRCODE_INTERNAL_ERROR),
                  errmsg("failed to insert message into queue: %s", SPI_result_code_string(ret))));
 
+    {
+        bool id_null = true;
+        int64 message_id =
+            DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &id_null));
+
+        if (!id_null)
+            ulak_wake_mark(message_id, NULL, false);
+    }
+
     SPI_finish();
 
-    /* Note: pg_notify will be called by the trigger after commit */
     elog(DEBUG1, "[ulak] Message queued successfully for endpoint_id: %lld",
          (long long)endpoint_id);
 

--- a/src/wake.c
+++ b/src/wake.c
@@ -1,0 +1,152 @@
+/**
+ * @file wake.c
+ * @brief Wake delivery workers when a transaction that queued messages commits.
+ *
+ * Every INSERT into ulak.queue used to NOTIFY 'ulak_new_msg'. NOTIFY is only
+ * delivered at commit, and to keep notifications in commit order PostgreSQL
+ * serialises every notifying transaction behind one database-wide
+ * AccessExclusiveLock from PreCommit_Notify() until the commit is complete
+ * (src/backend/commands/async.c). With many concurrent senders that lock caps
+ * the notifying commits at a few thousand per second no matter how many
+ * clients there are, and their commit latency grows linearly with the client
+ * count. Sending a message therefore capped the application's own commit rate.
+ *
+ * The extension does not need NOTIFY: the workers' latches live in shared
+ * memory (PGPROC), so a sender records which partitions received rows and a
+ * transaction callback sets those latches once the commit is visible —
+ * CallXactCallbacks(XACT_EVENT_COMMIT) runs after RecordTransactionCommit()
+ * and ProcArrayEndTransaction(). No lock, no queue, and a busy worker costs
+ * nothing (SetLatch only signals a process that is actually sleeping).
+ *
+ * NOTIFY is still queued when ulak.wake_notify is on, for external worker
+ * processes that share the queue with the extension and can only LISTEN; it
+ * is throttled per session by ulak.notify_throttle_ms.
+ */
+
+#include "postgres.h"
+
+#include "access/xact.h"
+#include "catalog/pg_collation.h"
+#include "commands/async.h"
+#include "fmgr.h"
+#include "miscadmin.h"
+#include "utils/builtins.h"
+#include "utils/fmgrprotos.h"
+#include "utils/timestamp.h"
+
+#include "config/guc.h"
+#include "shmem.h"
+#include "wake.h"
+
+/* Partitions that received rows in the current transaction (bit = worker_id) */
+static uint32 pending_mask = 0;
+/* Set by ulak_send() while its INSERT runs; see ulak_wake_set_skip_trigger() */
+static bool skip_trigger = false;
+static bool callback_registered = false;
+/* Last NOTIFY queued by this backend (ulak.wake_notify throttle) */
+static TimestampTz last_notify_at = 0;
+
+/**
+ * @brief Transaction callback: set the marked workers' latches after commit.
+ */
+static void wake_xact_callback(XactEvent event, void *arg) {
+    (void)arg;
+
+    switch (event) {
+    case XACT_EVENT_COMMIT:
+    case XACT_EVENT_PARALLEL_COMMIT:
+        if (pending_mask != 0)
+            ulak_wake_workers(MyDatabaseId, pending_mask);
+        pending_mask = 0;
+        skip_trigger = false;
+        break;
+
+    case XACT_EVENT_ABORT:
+    case XACT_EVENT_PARALLEL_ABORT:
+    case XACT_EVENT_PREPARE:
+        /*
+         * Nothing became visible. For PREPARE the rows appear at COMMIT
+         * PREPARED, possibly from another backend; ulak.poll_interval covers
+         * them. (NOTIFY refuses PREPARE outright, so this is still a gain.)
+         */
+        pending_mask = 0;
+        skip_trigger = false;
+        break;
+
+    default:
+        break;
+    }
+}
+
+/**
+ * @brief Same partition formula as the claim query in batch_processor.c:
+ *        (ordering_key IS NULL ? id : abs(hashtext(ordering_key))) % workers.
+ */
+static int wake_partition_of(int64 message_id, const char *ordering_key) {
+    int workers = ulak_workers > 0 ? ulak_workers : 1;
+    int64 value;
+
+    if (ordering_key == NULL) {
+        value = message_id;
+    } else {
+        /* hashtext needs a collation; the column uses the database default */
+        int32 hash = DatumGetInt32(DirectFunctionCall1Coll(hashtext, DEFAULT_COLLATION_OID,
+                                                           CStringGetTextDatum(ordering_key)));
+        value = hash < 0 ? -(int64)hash : (int64)hash;
+    }
+    if (value < 0)
+        value = -value;
+
+    return (int)(value % workers);
+}
+
+/**
+ * @brief Queue a NOTIFY for external LISTENers, at most once per throttle window.
+ */
+static void wake_maybe_notify(void) {
+    TimestampTz now = GetCurrentTimestamp();
+
+    if (ulak_notify_throttle_ms > 0 && last_notify_at != 0 &&
+        now < TimestampTzPlusMilliseconds(last_notify_at, ulak_notify_throttle_ms))
+        return;
+
+    last_notify_at = now;
+    Async_Notify("ulak_new_msg", NULL);
+}
+
+void ulak_wake_mark(int64 message_id, const char *ordering_key, bool all_partitions) {
+    int workers = ulak_workers > 0 ? ulak_workers : 1;
+
+    if (!callback_registered) {
+        RegisterXactCallback(wake_xact_callback, NULL);
+        callback_registered = true;
+    }
+
+    if (all_partitions || workers >= 32)
+        pending_mask |= (workers >= 32) ? 0xFFFFFFFFu : ((1u << workers) - 1u);
+    else
+        pending_mask |= 1u << wake_partition_of(message_id, ordering_key);
+
+    if (ulak_wake_notify)
+        wake_maybe_notify();
+}
+
+void ulak_wake_set_skip_trigger(bool skip) { skip_trigger = skip; }
+
+PG_FUNCTION_INFO_V1(ulak_wake_workers_sql);
+Datum ulak_wake_workers_sql(PG_FUNCTION_ARGS) {
+    if (skip_trigger)
+        PG_RETURN_VOID();
+
+    if (PG_ARGISNULL(0)) {
+        ulak_wake_mark(0, NULL, true);
+    } else {
+        char *key = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+        ulak_wake_mark(PG_GETARG_INT64(0), key, false);
+        if (key != NULL)
+            pfree(key);
+    }
+
+    PG_RETURN_VOID();
+}

--- a/src/wake.h
+++ b/src/wake.h
@@ -1,0 +1,36 @@
+/**
+ * @file wake.h
+ * @brief Commit-time wake-up of delivery workers (replaces per-insert NOTIFY).
+ */
+#ifndef ULAK_WAKE_H
+#define ULAK_WAKE_H
+
+#include "fmgr.h"
+#include "postgres.h"
+
+/**
+ * @brief Record that the current transaction queued a message.
+ *
+ * The matching worker latch (or every latch when @p all_partitions is set)
+ * is set from a transaction callback once the commit is visible. When
+ * ulak.wake_notify is on, a throttled NOTIFY 'ulak_new_msg' is queued too.
+ *
+ * @param message_id     Queue row id (partition key for unkeyed messages).
+ * @param ordering_key   Ordering key or NULL; keyed messages hash to a partition.
+ * @param all_partitions Wake every worker (batch inserts, unknown rows).
+ */
+extern void ulak_wake_mark(int64 message_id, const char *ordering_key, bool all_partitions);
+
+/**
+ * @brief Make the queue trigger's ulak._wake_workers() call a no-op.
+ *
+ * ulak_send() inserts one row and knows its id, so it marks the exact
+ * partition itself instead of letting the statement trigger wake all workers.
+ * Reset automatically at transaction end.
+ */
+extern void ulak_wake_set_skip_trigger(bool skip);
+
+/** SQL entry point: ulak._wake_workers(p_id bigint, p_ordering_key text). */
+extern Datum ulak_wake_workers_sql(PG_FUNCTION_ARGS);
+
+#endif /* ULAK_WAKE_H */

--- a/src/worker.c
+++ b/src/worker.c
@@ -398,7 +398,11 @@ static void ulak_worker_loop(void) {
             if (IsTransactionState())
                 AbortCurrentTransaction();
 
-            /* Clean up orphaned batch context + reset local stats (batch not committed) */
+            /* Rows claimed by the interrupted batch go back to pending now
+             * rather than after stale_recovery_timeout */
+            batch_processor_release_claimed();
+
+            /* Clean up orphaned batch context + reset local stats */
             batch_processor_cleanup_on_error();
 
             /* Error recovery: flush dispatcher cache to avoid reusing

--- a/src/worker.c
+++ b/src/worker.c
@@ -101,7 +101,7 @@ PGDLLEXPORT void ulak_worker_main(Datum main_arg) {
     worker_dboid = MyDatabaseId;
     ulak_register_database(worker_dbname, worker_dboid);
     ulak_set_target_workers(worker_dboid, total_workers);
-    (void)ulak_add_worker_pid(worker_dboid, MyProcPid, worker_id);
+    (void)ulak_add_worker_pid(worker_dboid, MyProcPid, worker_id, MyLatch);
 
     /* Set up signal handlers - MyLatch is now initialized */
     ulak_pqsignal(SIGTERM, ulak_sigterm_handler);
@@ -188,7 +188,7 @@ static void ulak_worker_loop(void) {
             }
         }
 
-        /* Wait for notifications or timeout */
+        /* Wait for a latch wake-up (wake.c, or NOTIFY with ulak.wake_notify) or the poll timeout */
         rc = WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
                        (long)ulak_poll_interval, PG_WAIT_EXTENSION);
 
@@ -233,7 +233,9 @@ static void ulak_worker_loop(void) {
             elog(LOG, "[ulak] Extension detected, worker starting");
         }
 
-        /* One-time setup: subscribe to notifications */
+        /* One-time setup: subscribe to notifications. Since the commit-time
+         * latch wake-up (wake.c) this only matters when ulak.wake_notify is on
+         * or the catalog still carries a pre-0.2.0 trigger that NOTIFYs. */
         if (!listener_registered) {
             StartTransactionCommand();
             Async_Listen("ulak_new_msg");

--- a/src/worker/batch_processor.c
+++ b/src/worker/batch_processor.c
@@ -79,6 +79,8 @@ static void worker_flush_stats_to_shmem(Oid worker_dboid, int worker_id) {
     worker_local_stats.last_error_msg[0] = '\0';
 }
 
+static void batch_heartbeat_if_due(void);
+
 /* ------------------------------------------------------------------------
  * Batch memory context
  * ------------------------------------------------------------------------ */
@@ -313,6 +315,8 @@ static void process_endpoint_batch(MessageBatchInfo *messages, int count, const 
 
             if (messages[i].rate_limited)
                 continue;
+            /* Long synchronous groups: keep stale recovery away from our rows */
+            batch_heartbeat_if_due();
 
             use_dispatch_ex = (dispatcher->ops->dispatch_ex != NULL) &&
                               (ulak_capture_response || messages[i].headers != NULL ||
@@ -360,906 +364,1012 @@ static void process_endpoint_batch(MessageBatchInfo *messages, int count, const 
 
 /* ------------------------------------------------------------------------
  * Batch entry point
+ *
+ * A batch runs in three phases so that no database transaction stays open
+ * while the worker talks to brokers:
+ *
+ *   1. claim   — one transaction: SELECT … FOR UPDATE SKIP LOCKED, copy the
+ *                rows into the batch memory context, mark them 'processing',
+ *                apply circuit-breaker deferrals, COMMIT.
+ *   2. deliver — no transaction: dispatch per endpoint. A slow or dead
+ *                broker now costs only this worker's time, not row locks,
+ *                snapshot age or a transaction held open for the whole
+ *                delivery timeout.
+ *   3. write   — one transaction: status updates, retries, DLQ archive,
+ *                circuit-breaker bookkeeping, COMMIT.
+ *
+ * A worker that dies between 1 and 3 leaves rows in 'processing'; stale
+ * recovery (ulak.stale_recovery_timeout) returns them to 'pending'. An
+ * error raised between 1 and 3 goes through batch_processor_release_claimed()
+ * from the worker's PG_CATCH, which puts the rows back immediately.
  * ------------------------------------------------------------------------ */
 
-int64 batch_processor_run(Oid worker_dboid, int worker_id, int total_workers) {
-    int ret;
-    int spi_ret;
-    int64 messages_processed = 0;
-    int64 fetched_count = 0;
-    MemoryContext batch_context;
-    MemoryContext old_context;
-    MemoryContext spi_context;
+/* Rows claimed by the current batch, for release on error (see above). */
+static struct {
+    MessageBatchInfo *messages;
+    uint64 count;
+    bool claimed; /* the claim transaction has committed */
+} in_flight = {NULL, 0, false};
 
-    /* Start transaction for SPI operations */
+/*
+ * Heartbeat. Claimed rows are 'processing' in a committed transaction, so
+ * stale recovery (ulak.stale_recovery_timeout) would hand them to another
+ * worker if a batch delivered for longer than that. Between endpoint groups
+ * and between synchronous deliveries the worker therefore refreshes
+ * processing_started_at of its in-flight rows once a quarter of the timeout
+ * has passed since the claim or the last refresh. A single uninterruptible
+ * wait (one batch flush, one HTTP request) must stay below the remaining
+ * three quarters, i.e. endpoint timeouts must be well below
+ * stale_recovery_timeout.
+ */
+static TimestampTz batch_last_heartbeat = 0;
+
+static void batch_heartbeat_if_due(void) {
+    static const char *touch_query = "UPDATE ulak.queue SET processing_started_at = NOW() "
+                                     "WHERE id = ANY($1::bigint[]) AND status = 'processing'";
+    MemoryContext caller_context = CurrentMemoryContext;
+    int64 interval_us = (int64)config_get_stale_recovery_timeout() * 250000; /* timeout / 4 */
+    TimestampTz now;
+    Datum *ids;
+    ArrayType *id_array;
+    uint64 i;
+    int ret;
+
+    if (!in_flight.claimed || in_flight.messages == NULL || in_flight.count == 0)
+        return;
+    now = GetCurrentTimestamp();
+    if (batch_last_heartbeat != 0 && now < batch_last_heartbeat + interval_us)
+        return;
+
     SetCurrentStatementStartTimestamp();
     StartTransactionCommand();
-    spi_ret = SPI_connect();
-    if (spi_ret != SPI_OK_CONNECT) {
-        elog(WARNING, "[ulak] SPI_connect failed in batch processing: %s",
-             SPI_result_code_string(spi_ret));
+    if (SPI_connect() != SPI_OK_CONNECT) {
         AbortCurrentTransaction();
-        return 0;
+        MemoryContextSwitchTo(caller_context);
+        return;
     }
+    PushActiveSnapshot(GetTransactionSnapshot());
+    ids = palloc(sizeof(Datum) * in_flight.count);
+    for (i = 0; i < in_flight.count; i++)
+        ids[i] = Int64GetDatum(in_flight.messages[i].message_id);
+    id_array = construct_array(ids, in_flight.count, INT8OID, sizeof(int64), true, TYPALIGN_DOUBLE);
+    ret = SPI_execute_with_args(touch_query, 1, (Oid[]){INT8ARRAYOID},
+                                (Datum[]){PointerGetDatum(id_array)}, NULL, false, 0);
+    if (ret != SPI_OK_UPDATE)
+        elog(WARNING, "[ulak] Heartbeat for %llu in-flight messages failed: SPI error %d",
+             (unsigned long long)in_flight.count, ret);
+    else
+        elog(DEBUG1, "[ulak] Heartbeat refreshed %llu in-flight messages",
+             (unsigned long long)SPI_processed);
+    PopActiveSnapshot();
+    SPI_finish();
+    CommitTransactionCommand();
+    MemoryContextSwitchTo(caller_context);
+    batch_last_heartbeat = now;
+}
 
-    /*
-     * Save the SPI memory context so we can switch back to it before any
-     * SPI calls.  batch_context is a child of TopMemoryContext used for
-     * palloc/pstrdup of message field copies; it is deleted at the end of
-     * the batch to free all message data at once.
-     */
-    spi_context = CurrentMemoryContext;
-    old_context = CurrentMemoryContext;
-    batch_context = AllocSetContextCreate(TopMemoryContext, "ulak batch", ALLOCSET_DEFAULT_SIZES);
-    worker_batch_context = batch_context;
+/**
+ * @brief Put the claimed rows of a batch back to 'pending' in a fresh transaction.
+ *
+ * Best effort: on failure the rows stay 'processing' and stale recovery
+ * picks them up. Safe to call with no batch in flight.
+ */
+static void batch_release_claimed_rows(MessageBatchInfo *messages, uint64 count) {
+    static const char *release_query =
+        "UPDATE ulak.queue SET status = 'pending', processing_started_at = NULL, "
+        "next_retry_at = NOW() WHERE id = ANY($1::bigint[]) AND status = 'processing'";
+    MemoryContext caller_context = CurrentMemoryContext;
+    Datum *ids;
+    ArrayType *id_array;
+    uint64 i;
+    int ret;
 
-    /*
-     * Use READ COMMITTED isolation level for multi-worker compatibility.
-     * REPEATABLE READ causes serialization failures (SQLSTATE 40001) when
-     * multiple workers try to FOR UPDATE SKIP LOCKED on the same rows.
-     * READ COMMITTED + SKIP LOCKED is the correct pattern for concurrent
-     * queue consumers — each worker sees its own consistent view of the
-     * rows it locks, without conflicting with other workers.
-     */
+    if (messages == NULL || count == 0)
+        return;
 
-    /*
-     * Disable synchronous_commit for worker transactions.
-     * Worker status updates (pending→processing→completed) are idempotent
-     * and will be retried on crash, so we trade durability for ~2-3x
-     * faster writes. This is safe because the ulak pattern guarantees
-     * at-least-once delivery.
-     */
-    SPI_execute_with_args("SET LOCAL synchronous_commit = off", 0, NULL, NULL, NULL, false, 0);
-
+    SetCurrentStatementStartTimestamp();
+    StartTransactionCommand();
+    if (SPI_connect() != SPI_OK_CONNECT) {
+        AbortCurrentTransaction();
+        MemoryContextSwitchTo(caller_context);
+        elog(WARNING,
+             "[ulak] Could not release %llu claimed messages (SPI_connect failed); "
+             "stale recovery will return them to pending",
+             (unsigned long long)count);
+        return;
+    }
     PushActiveSnapshot(GetTransactionSnapshot());
 
-    /* First check if extension schema and tables exist */
+    ids = palloc(sizeof(Datum) * count);
+    for (i = 0; i < count; i++)
+        ids[i] = Int64GetDatum(messages[i].message_id);
+    id_array = construct_array(ids, count, INT8OID, sizeof(int64), true, TYPALIGN_DOUBLE);
+    ret = SPI_execute_with_args(release_query, 1, (Oid[]){INT8ARRAYOID},
+                                (Datum[]){PointerGetDatum(id_array)}, NULL, false, 0);
+    if (ret == SPI_OK_UPDATE)
+        elog(LOG, "[ulak] Released %llu of %llu claimed messages back to pending",
+             (unsigned long long)SPI_processed, (unsigned long long)count);
+    else
+        elog(WARNING,
+             "[ulak] Could not release claimed messages (SPI error %d); "
+             "stale recovery will return them to pending",
+             ret);
+
+    PopActiveSnapshot();
+    SPI_finish();
+    CommitTransactionCommand();
+    MemoryContextSwitchTo(caller_context);
+}
+
+void batch_processor_release_claimed(void) {
+    MessageBatchInfo *messages = in_flight.messages;
+    uint64 count = in_flight.count;
+    bool claimed = in_flight.claimed;
+
+    in_flight.messages = NULL;
+    in_flight.count = 0;
+    in_flight.claimed = false;
+
+    if (!claimed || messages == NULL || count == 0)
+        return;
+
+    /* Nested PG_TRY is fine here: the caller has already flushed the error
+     * state and aborted the failed transaction. */
+    PG_TRY();
+    {
+        batch_release_claimed_rows(messages, count);
+    }
+    PG_CATCH();
+    {
+        ErrorData *edata = CopyErrorData();
+        FreeErrorData(edata);
+        FlushErrorState();
+        if (IsTransactionState())
+            AbortCurrentTransaction();
+        elog(WARNING, "[ulak] Releasing claimed messages failed; stale recovery will "
+                      "return them to pending");
+    }
+    PG_END_TRY();
+}
+
+/**
+ * @brief Phase 1: claim a batch and commit.
+ *
+ * On return with *count > 0 the rows are 'processing' in a committed
+ * transaction and *messages (in batch_context) describes them. Circuit
+ * breaker decisions are applied here too: rows behind an open circuit are
+ * returned to 'pending' with a retry delay and flagged `deferred` so the
+ * delivery phase skips them.
+ *
+ * @return false when the batch could not be claimed (error already logged).
+ */
+static bool batch_claim(int worker_id, int total_workers, MemoryContext batch_context,
+                        MessageBatchInfo **messages, uint64 *count) {
+    MemoryContext caller_context = CurrentMemoryContext;
+    MemoryContext spi_context;
+    StringInfoData query;
+    int ret;
+    MessageBatchInfo *all_messages;
+    TupleDesc tupdesc;
+    uint64 total_messages;
+    uint64 i;
+    uint64 batch_start;
+    uint64 batch_end;
+
+    *messages = NULL;
+    *count = 0;
+
+    SetCurrentStatementStartTimestamp();
+    StartTransactionCommand();
+    if (SPI_connect() != SPI_OK_CONNECT) {
+        elog(WARNING, "[ulak] SPI_connect failed in batch claim");
+        AbortCurrentTransaction();
+        MemoryContextSwitchTo(caller_context);
+        return false;
+    }
+    spi_context = CurrentMemoryContext;
+
+    /*
+     * READ COMMITTED + SKIP LOCKED is the pattern for concurrent queue
+     * consumers; REPEATABLE READ would raise serialization failures between
+     * workers. synchronous_commit is off for worker transactions: the
+     * status transitions are idempotent and redone after a crash, so we
+     * trade durability of the bookkeeping for faster commits.
+     */
+    SPI_execute_with_args("SET LOCAL synchronous_commit = off", 0, NULL, NULL, NULL, false, 0);
+    PushActiveSnapshot(GetTransactionSnapshot());
+
+    /* Extension schema present? (worker may start before CREATE EXTENSION) */
     ret = SPI_execute_with_args("SELECT 1 FROM pg_namespace WHERE nspname = 'ulak'", 0, NULL, NULL,
                                 NULL, true, 1);
     if (ret != SPI_OK_SELECT || SPI_processed == 0) {
-        /* Extension not installed in this database, skip */
         PopActiveSnapshot();
         SPI_finish();
         CommitTransactionCommand();
-        if (batch_context)
-            MemoryContextSwitchTo(old_context);
-        if (batch_context) {
-            MemoryContextDelete(batch_context);
-            worker_batch_context = NULL;
-        }
-        return 0;
+        MemoryContextSwitchTo(caller_context);
+        return false;
     }
 
-    /* Select pending messages WITH endpoint info in a single query.
-     * Uses parameterized query to prevent SQL injection. */
-    {
-        StringInfoData query;
+    /*
+     * Select pending messages with their endpoint in one query. Workers
+     * partition the queue: unkeyed rows by id, keyed rows by
+     * abs(hashtext(ordering_key)), so per-key FIFO holds with N workers.
+     * For a keyed row only the head of its key is eligible (no 'processing'
+     * row and no lower pending id with the same key).
+     */
+    initStringInfo(&query);
+    appendStringInfo(&query,
+                     "SELECT q.id, q.endpoint_id, q.payload, q.retry_count, "
+                     "       e.protocol, e.config, e.retry_policy, "
+                     "       q.priority, q.scheduled_at, q.expires_at, q.correlation_id, "
+                     "       e.enabled, e.circuit_failure_count, e.circuit_state, "
+                     "       e.circuit_opened_at, e.circuit_half_open_at, "
+                     "       q.headers, q.metadata "
+                     "FROM ulak.queue q "
+                     "JOIN ulak.endpoints e ON q.endpoint_id = e.id "
+                     "WHERE q.status = '%s' "
+                     "  AND e.enabled = true "
+                     "  AND (q.next_retry_at IS NULL OR q.next_retry_at <= NOW()) "
+                     "  AND (q.scheduled_at IS NULL OR q.scheduled_at <= NOW()) "
+                     "  AND (q.expires_at IS NULL OR q.expires_at > NOW()) "
+                     "  AND (q.ordering_key IS NULL "
+                     "       OR (NOT EXISTS ("
+                     "               SELECT 1 FROM ulak.queue q2 "
+                     "               WHERE q2.ordering_key = q.ordering_key "
+                     "                 AND q2.status = 'processing') "
+                     "           AND NOT EXISTS ("
+                     "               SELECT 1 FROM ulak.queue q2 "
+                     "               WHERE q2.ordering_key = q.ordering_key "
+                     "                 AND q2.status = 'pending' "
+                     "                 AND q2.id < q.id))) ",
+                     STATUS_PENDING);
+    if (total_workers > 1)
+        appendStringInfo(&query,
+                         "  AND ((CASE WHEN q.ordering_key IS NULL THEN q.id "
+                         "             ELSE abs(hashtext(q.ordering_key))::bigint "
+                         "        END) %% %d) = %d ",
+                         total_workers, worker_id);
+    appendStringInfo(&query,
+                     "ORDER BY q.priority DESC, q.endpoint_id, q.created_at ASC "
+                     "LIMIT %d FOR UPDATE OF q SKIP LOCKED",
+                     ulak_batch_size);
 
-        initStringInfo(&query);
+    ret = SPI_execute(query.data, false, 0);
+    pfree(query.data);
 
-        /*
-         * Multi-worker partitioning: Each worker processes a disjoint subset of messages
-         * using modulo partitioning on the message ID. This ensures:
-         * - No contention between workers (each owns a partition)
-         * - Deterministic assignment (same message always goes to same worker)
-         * - Even distribution (sequential IDs spread evenly)
-         *
-         * Added priority ordering, scheduled_at, expires_at, and enabled endpoint checks
-         */
-        if (total_workers > 1) {
-            appendStringInfo(&query,
-                             "SELECT q.id, q.endpoint_id, q.payload, q.retry_count, "
-                             "       e.protocol, e.config, e.retry_policy, "
-                             "       q.priority, q.scheduled_at, q.expires_at, q.correlation_id, "
-                             "       e.enabled, e.circuit_failure_count, e.circuit_state, "
-                             "       e.circuit_opened_at, e.circuit_half_open_at, "
-                             "       q.headers, q.metadata "
-                             "FROM ulak.queue q "
-                             "JOIN ulak.endpoints e ON q.endpoint_id = e.id "
-                             "WHERE q.status = '%s' "
-                             "  AND e.enabled = true "
-                             "  AND (q.next_retry_at IS NULL OR q.next_retry_at <= NOW()) "
-                             "  AND (q.scheduled_at IS NULL OR q.scheduled_at <= NOW()) "
-                             "  AND (q.expires_at IS NULL OR q.expires_at > NOW()) "
-                             "  AND (q.ordering_key IS NULL "
-                             "       OR (NOT EXISTS ("
-                             "               SELECT 1 FROM ulak.queue q2 "
-                             "               WHERE q2.ordering_key = q.ordering_key "
-                             "                 AND q2.status = 'processing') "
-                             "           AND NOT EXISTS ("
-                             "               SELECT 1 FROM ulak.queue q2 "
-                             "               WHERE q2.ordering_key = q.ordering_key "
-                             "                 AND q2.status = 'pending' "
-                             "                 AND q2.id < q.id))) "
-                             /*
-                              * Hash-partition by ordering_key when set so all
-                              * messages sharing a key route to the same worker;
-                              * id-based fallback preserves balance for unkeyed
-                              * messages. Required for per-key FIFO under N>1.
-                              */
-                             "  AND ((CASE WHEN q.ordering_key IS NULL THEN q.id "
-                             "             ELSE abs(hashtext(q.ordering_key))::bigint "
-                             "        END) %% %d) = %d "
-                             "ORDER BY q.priority DESC, q.endpoint_id, q.created_at ASC "
-                             "LIMIT %d FOR UPDATE OF q SKIP LOCKED",
-                             STATUS_PENDING, total_workers, worker_id, ulak_batch_size);
+    if (ret != SPI_OK_SELECT) {
+        elog(WARNING, "[ulak] Failed to query pending messages: SPI error %d", ret);
+        PopActiveSnapshot();
+        SPI_finish();
+        AbortCurrentTransaction();
+        MemoryContextSwitchTo(caller_context);
+        return false;
+    }
+    if (SPI_processed == 0 || SPI_tuptable == NULL) {
+        PopActiveSnapshot();
+        SPI_finish();
+        CommitTransactionCommand();
+        MemoryContextSwitchTo(caller_context);
+        return true; /* nothing pending */
+    }
+
+    total_messages = SPI_processed;
+    tupdesc = SPI_tuptable->tupdesc;
+    if (tupdesc->natts < 18) {
+        elog(WARNING, "[ulak] Query returned unexpected column count: %d (expected 18)",
+             tupdesc->natts);
+        PopActiveSnapshot();
+        SPI_finish();
+        AbortCurrentTransaction();
+        MemoryContextSwitchTo(caller_context);
+        return false;
+    }
+
+    /* Copy every field into batch_context: the SPI result and the
+     * transaction are gone before delivery starts. */
+    MemoryContextSwitchTo(batch_context);
+    all_messages = palloc0(sizeof(MessageBatchInfo) * total_messages);
+
+    for (i = 0; i < total_messages; i++) {
+        HeapTuple tuple = SPI_tuptable->vals[i];
+        bool isnull;
+        Datum datum;
+
+        all_messages[i].message_id = DatumGetInt64(SPI_getbinval(tuple, tupdesc, 1, &isnull));
+        all_messages[i].endpoint_id = DatumGetInt64(SPI_getbinval(tuple, tupdesc, 2, &isnull));
+
+        datum = SPI_getbinval(tuple, tupdesc, 3, &isnull);
+        if (isnull) {
+            all_messages[i].payload_str = pstrdup("{}");
         } else {
-            /* Single worker - no partitioning needed */
-            appendStringInfo(&query,
-                             "SELECT q.id, q.endpoint_id, q.payload, q.retry_count, "
-                             "       e.protocol, e.config, e.retry_policy, "
-                             "       q.priority, q.scheduled_at, q.expires_at, q.correlation_id, "
-                             "       e.enabled, e.circuit_failure_count, e.circuit_state, "
-                             "       e.circuit_opened_at, e.circuit_half_open_at, "
-                             "       q.headers, q.metadata "
-                             "FROM ulak.queue q "
-                             "JOIN ulak.endpoints e ON q.endpoint_id = e.id "
-                             "WHERE q.status = '%s' "
-                             "  AND e.enabled = true "
-                             "  AND (q.next_retry_at IS NULL OR q.next_retry_at <= NOW()) "
-                             "  AND (q.scheduled_at IS NULL OR q.scheduled_at <= NOW()) "
-                             "  AND (q.expires_at IS NULL OR q.expires_at > NOW()) "
-                             "  AND (q.ordering_key IS NULL "
-                             "       OR (NOT EXISTS ("
-                             "               SELECT 1 FROM ulak.queue q2 "
-                             "               WHERE q2.ordering_key = q.ordering_key "
-                             "                 AND q2.status = 'processing') "
-                             "           AND NOT EXISTS ("
-                             "               SELECT 1 FROM ulak.queue q2 "
-                             "               WHERE q2.ordering_key = q.ordering_key "
-                             "                 AND q2.status = 'pending' "
-                             "                 AND q2.id < q.id))) "
-                             "ORDER BY q.priority DESC, q.endpoint_id, q.created_at ASC "
-                             "LIMIT %d FOR UPDATE OF q SKIP LOCKED",
-                             STATUS_PENDING, ulak_batch_size);
+            Jsonb *payload = DatumGetJsonbP(datum);
+            all_messages[i].payload_str = JsonbToCString(NULL, &payload->root, VARSIZE(payload));
         }
 
-        ret = SPI_execute(query.data, false, 0);
-        pfree(query.data);
+        all_messages[i].retry_count = DatumGetInt32(SPI_getbinval(tuple, tupdesc, 4, &isnull));
 
-        if (ret == SPI_OK_SELECT && SPI_processed > 0 && SPI_tuptable != NULL) {
-            uint64 total_messages = SPI_processed;
-            MessageBatchInfo *all_messages;
-            TupleDesc tupdesc;
-            uint64 i;
-            uint64 batch_start;
-            uint64 batch_end;
-            int64 current_endpoint_id;
-            int batch_count;
-            char *protocol_str;
-            Jsonb *config;
-            Jsonb *retry_policy;
-            int failed_updates = 0;
+        datum = SPI_getbinval(tuple, tupdesc, 5, &isnull);
+        if (isnull) {
+            elog(WARNING, "[ulak] NULL protocol for message %lld, skipping",
+                 (long long)all_messages[i].message_id);
+            all_messages[i].processed = true;
+            all_messages[i].success = false;
+            all_messages[i].error_message = pstrdup("Endpoint protocol is NULL");
+            continue;
+        }
+        all_messages[i].protocol = text_to_cstring(DatumGetTextPP(datum));
 
-            /* Verify tuple descriptor has expected columns (18 columns) */
-            tupdesc = SPI_tuptable->tupdesc;
-            if (tupdesc->natts < 18) {
-                elog(WARNING, "[ulak] Query returned unexpected column count: %d (expected 18)",
-                     tupdesc->natts);
-                PopActiveSnapshot();
-                SPI_finish();
-                CommitTransactionCommand();
-                MemoryContextSwitchTo(spi_context);
-                MemoryContextDelete(batch_context);
-                worker_batch_context = NULL;
-                return 0;
+        datum = SPI_getbinval(tuple, tupdesc, 6, &isnull);
+        if (isnull) {
+            elog(WARNING, "[ulak] NULL config for message %lld, skipping",
+                 (long long)all_messages[i].message_id);
+            all_messages[i].processed = true;
+            all_messages[i].success = false;
+            all_messages[i].error_message = pstrdup("Endpoint config is NULL");
+            continue;
+        }
+        {
+            Jsonb *config_jsonb = DatumGetJsonbP(datum);
+            all_messages[i].config = (Jsonb *)palloc(VARSIZE(config_jsonb));
+            memcpy(all_messages[i].config, config_jsonb, VARSIZE(config_jsonb));
+        }
+
+        datum = SPI_getbinval(tuple, tupdesc, 7, &isnull);
+        if (!isnull) {
+            Jsonb *rp = DatumGetJsonbP(datum);
+            all_messages[i].retry_policy = (Jsonb *)palloc(VARSIZE(rp));
+            memcpy(all_messages[i].retry_policy, rp, VARSIZE(rp));
+        }
+
+        all_messages[i].priority = DatumGetInt16(SPI_getbinval(tuple, tupdesc, 8, &isnull));
+        if (isnull)
+            all_messages[i].priority = 0;
+        all_messages[i].scheduled_at =
+            DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 9, &isnull));
+        if (isnull)
+            all_messages[i].scheduled_at = 0;
+        all_messages[i].expires_at =
+            DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 10, &isnull));
+        if (isnull)
+            all_messages[i].expires_at = 0;
+
+        datum = SPI_getbinval(tuple, tupdesc, 11, &isnull);
+        if (!isnull)
+            all_messages[i].correlation_id = DatumGetCString(DirectFunctionCall1(uuid_out, datum));
+
+        all_messages[i].endpoint_enabled = DatumGetBool(SPI_getbinval(tuple, tupdesc, 12, &isnull));
+        if (isnull)
+            all_messages[i].endpoint_enabled = true;
+        all_messages[i].endpoint_failure_count =
+            DatumGetInt32(SPI_getbinval(tuple, tupdesc, 13, &isnull));
+        if (isnull)
+            all_messages[i].endpoint_failure_count = 0;
+
+        datum = SPI_getbinval(tuple, tupdesc, 14, &isnull);
+        if (!isnull) {
+            char *cs_str = text_to_cstring(DatumGetTextPP(datum));
+            strlcpy(all_messages[i].circuit_state, cs_str, sizeof(all_messages[i].circuit_state));
+            pfree(cs_str);
+        } else {
+            strlcpy(all_messages[i].circuit_state, "closed", sizeof(all_messages[i].circuit_state));
+        }
+        all_messages[i].circuit_opened_at =
+            DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 15, &isnull));
+        if (isnull)
+            all_messages[i].circuit_opened_at = 0;
+        all_messages[i].circuit_half_open_at =
+            DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 16, &isnull));
+        if (isnull)
+            all_messages[i].circuit_half_open_at = 0;
+
+        datum = SPI_getbinval(tuple, tupdesc, 17, &isnull);
+        if (!isnull) {
+            Jsonb *hdr = DatumGetJsonbP(datum);
+            all_messages[i].headers = (Jsonb *)palloc(VARSIZE(hdr));
+            memcpy(all_messages[i].headers, hdr, VARSIZE(hdr));
+        }
+        datum = SPI_getbinval(tuple, tupdesc, 18, &isnull);
+        if (!isnull) {
+            Jsonb *meta = DatumGetJsonbP(datum);
+            all_messages[i].metadata = (Jsonb *)palloc(VARSIZE(meta));
+            memcpy(all_messages[i].metadata, meta, VARSIZE(meta));
+        }
+    }
+    MemoryContextSwitchTo(spi_context);
+
+    /* Mark all claimed rows 'processing' in one UPDATE */
+    {
+        static const char *mark_processing_query =
+            "UPDATE ulak.queue SET status = 'processing', "
+            "processing_started_at = NOW() WHERE id = ANY($1::bigint[])";
+        Datum *mark_ids = palloc(sizeof(Datum) * total_messages);
+        ArrayType *mark_array;
+
+        for (i = 0; i < total_messages; i++)
+            mark_ids[i] = Int64GetDatum(all_messages[i].message_id);
+        mark_array = construct_array(mark_ids, total_messages, INT8OID, sizeof(int64), true,
+                                     TYPALIGN_DOUBLE);
+        ret = SPI_execute_with_args(mark_processing_query, 1, (Oid[]){INT8ARRAYOID},
+                                    (Datum[]){PointerGetDatum(mark_array)}, NULL, false, 0);
+        pfree(mark_ids);
+        if (ret != SPI_OK_UPDATE || SPI_processed != total_messages) {
+            /* Delivering rows we did not manage to claim is not an option. */
+            elog(WARNING, "[ulak] Failed to mark %llu messages as processing (SPI %d, %llu rows)",
+                 (unsigned long long)total_messages, ret, (unsigned long long)SPI_processed);
+            PopActiveSnapshot();
+            SPI_finish();
+            AbortCurrentTransaction();
+            MemoryContextSwitchTo(caller_context);
+            return false;
+        }
+    }
+
+    /*
+     * Circuit breaker decisions, per endpoint group (rows are ordered by
+     * endpoint_id). Rows behind an open circuit go straight back to
+     * 'pending' with a delay in this same transaction and are flagged
+     * `deferred` so the delivery phase skips them. The breaker counters are
+     * left alone for deferred rows: nothing was attempted.
+     */
+    batch_start = 0;
+    while (batch_start < total_messages) {
+        int64 endpoint_id = all_messages[batch_start].endpoint_id;
+        uint64 k;
+
+        batch_end = batch_start;
+        while (batch_end < total_messages && all_messages[batch_end].endpoint_id == endpoint_id)
+            batch_end++;
+
+        if (strcmp(all_messages[batch_start].circuit_state, "open") == 0) {
+            const char *defer_query;
+            uint64 defer_from = batch_start;
+
+            if (all_messages[batch_start].circuit_half_open_at > 0 &&
+                GetCurrentTimestamp() >= all_messages[batch_start].circuit_half_open_at) {
+                /* Cooldown elapsed: one worker wins the half_open transition and
+                 * sends the first row as the probe; everybody else defers. */
+                if (cb_try_half_open_transition(endpoint_id)) {
+                    elog(LOG, "[ulak] Circuit breaker half_open for endpoint %lld — sending probe",
+                         (long long)endpoint_id);
+                    defer_from = batch_start + 1;
+                    defer_query = "UPDATE ulak.queue SET status = 'pending', "
+                                  "processing_started_at = NULL, "
+                                  "next_retry_at = NOW() + '5 seconds'::interval, "
+                                  "last_error = 'Circuit breaker half_open - waiting for probe "
+                                  "result' WHERE id = $1";
+                } else {
+                    defer_query = "UPDATE ulak.queue SET status = 'pending', "
+                                  "processing_started_at = NULL, "
+                                  "next_retry_at = NOW() + '5 seconds'::interval, "
+                                  "last_error = 'Circuit breaker transition lost — another worker "
+                                  "is probing' WHERE id = $1";
+                }
+            } else {
+                defer_query = "UPDATE ulak.queue SET status = 'pending', "
+                              "processing_started_at = NULL, "
+                              "next_retry_at = NOW() + '10 seconds'::interval, "
+                              "last_error = 'Circuit breaker open - dispatch deferred' "
+                              "WHERE id = $1";
+                elog(DEBUG1,
+                     "[ulak] Deferred %llu messages for endpoint %lld: circuit breaker open",
+                     (unsigned long long)(batch_end - batch_start), (long long)endpoint_id);
             }
 
-            /* Switch to batch_context for all message field allocations */
-            MemoryContextSwitchTo(batch_context);
-            all_messages = palloc0(sizeof(MessageBatchInfo) * total_messages);
+            for (k = defer_from; k < batch_end; k++) {
+                SPI_execute_with_args(defer_query, 1, (Oid[]){INT8OID},
+                                      (Datum[]){Int64GetDatum(all_messages[k].message_id)}, NULL,
+                                      false, 0);
+                all_messages[k].deferred = true;
+                all_messages[k].processed = false;
+            }
+        }
+        batch_start = batch_end;
+    }
 
-            /* Collect all message info - MUST copy all data before any subsequent SPI calls */
+    PopActiveSnapshot();
+    SPI_finish();
+    CommitTransactionCommand();
+    MemoryContextSwitchTo(caller_context);
+
+    *messages = all_messages;
+    *count = total_messages;
+    return true;
+}
+
+/**
+ * @brief Phase 2: deliver every non-deferred row, endpoint by endpoint.
+ *
+ * Runs with no transaction open. Allocations (error strings, dispatch
+ * results) land in the current memory context, which the caller sets to
+ * the batch context.
+ */
+static void batch_deliver(MessageBatchInfo *all_messages, uint64 total_messages) {
+    uint64 batch_start = 0;
+
+    while (batch_start < total_messages) {
+        int64 endpoint_id = all_messages[batch_start].endpoint_id;
+        uint64 batch_end = batch_start;
+        uint64 live_end;
+
+        /* Allow timely SIGTERM / SIGHUP handling between endpoint groups */
+        CHECK_FOR_INTERRUPTS();
+
+        while (batch_end < total_messages && all_messages[batch_end].endpoint_id == endpoint_id)
+            batch_end++;
+
+        batch_heartbeat_if_due();
+
+        /* Deferred rows are a suffix of the group (all, or all but the probe) */
+        live_end = batch_start;
+        while (live_end < batch_end && !all_messages[live_end].deferred)
+            live_end++;
+
+        if (live_end > batch_start)
+            process_endpoint_batch(&all_messages[batch_start], (int)(live_end - batch_start),
+                                   all_messages[batch_start].protocol,
+                                   all_messages[batch_start].config,
+                                   all_messages[batch_start].retry_policy);
+
+        batch_start = batch_end;
+    }
+}
+
+/**
+ * @brief Phase 3: write the outcome of every row in one transaction.
+ *
+ * @return false when the transaction had to be aborted; the rows are then
+ *         still 'processing' and the caller releases them.
+ */
+static bool batch_write_results(MessageBatchInfo *all_messages, uint64 total_messages,
+                                int64 *messages_processed) {
+    MemoryContext caller_context = CurrentMemoryContext;
+    int64 processed = 0;
+    int failed_updates = 0;
+    int ret;
+    uint64 i;
+
+    *messages_processed = 0;
+
+    SetCurrentStatementStartTimestamp();
+    StartTransactionCommand();
+    if (SPI_connect() != SPI_OK_CONNECT) {
+        elog(WARNING, "[ulak] SPI_connect failed while writing batch results");
+        AbortCurrentTransaction();
+        MemoryContextSwitchTo(caller_context);
+        return false;
+    }
+    SPI_execute_with_args("SET LOCAL synchronous_commit = off", 0, NULL, NULL, NULL, false, 0);
+    PushActiveSnapshot(GetTransactionSnapshot());
+
+    {
+        /* Batch queries */
+        /*
+         * Every update is guarded with status = 'processing': the rows were
+         * ours when claimed, but stale recovery may have handed them to
+         * another worker while we were delivering. A row we no longer own is
+         * left alone (at-least-once; the new owner reports its own outcome).
+         */
+        static const char *batch_success_query =
+            "UPDATE ulak.queue SET status = 'completed', last_error = NULL, "
+            "completed_at = NOW(), updated_at = NOW() "
+            "WHERE id = ANY($1::bigint[]) AND status = 'processing'";
+        static const char *batch_revert_query =
+            "UPDATE ulak.queue q SET status = 'pending', "
+            "processing_started_at = NULL, "
+            "next_retry_at = NOW() + (v.defer_ms::text || ' milliseconds')::interval "
+            "FROM (SELECT unnest($1::bigint[]) AS id, "
+            "             unnest($2::int[]) AS defer_ms) v "
+            "WHERE q.id = v.id AND q.status = 'processing'";
+        static const char *batch_failed_query =
+            "UPDATE ulak.queue q SET status = 'failed', "
+            "retry_count = v.retry_count, last_error = v.last_error, "
+            "failed_at = NOW() "
+            "FROM (SELECT unnest($1::bigint[]) AS id, "
+            "             unnest($2::int[]) AS retry_count, "
+            "             unnest($3::text[]) AS last_error) v "
+            "WHERE q.id = v.id AND q.status = 'processing' RETURNING q.id";
+        static const char *batch_retry_query =
+            "UPDATE ulak.queue q SET status = 'pending', "
+            "retry_count = v.retry_count, last_error = v.last_error, "
+            "next_retry_at = NOW() + (v.delay_seconds || ' seconds')::interval "
+            "FROM (SELECT unnest($1::bigint[]) AS id, "
+            "             unnest($2::int[]) AS retry_count, "
+            "             unnest($3::text[]) AS last_error, "
+            "             unnest($4::text[]) AS delay_seconds) v "
+            "WHERE q.id = v.id AND q.status = 'processing'";
+        static const char *batch_dlq_query = "SELECT ulak.archive_single_to_dlq(id) "
+                                             "FROM unnest($1::bigint[]) AS id";
+        /* Individual query for response capture (unique per message) */
+        static const char *success_response_query =
+            "UPDATE ulak.queue SET status = $1, last_error = NULL, "
+            "completed_at = NOW(), response = $2::jsonb "
+            "WHERE id = $3 AND status = 'processing'";
+        /* Batch collection arrays */
+        Datum *success_ids = palloc(sizeof(Datum) * total_messages);
+        int success_count = 0;
+        Datum *rate_limited_ids = palloc(sizeof(Datum) * total_messages);
+        Datum *rate_limited_delays = palloc(sizeof(Datum) * total_messages);
+        int rate_limited_count = 0;
+        Datum *perm_fail_ids = palloc(sizeof(Datum) * total_messages);
+        Datum *perm_fail_retries = palloc(sizeof(Datum) * total_messages);
+        Datum *perm_fail_errors = palloc(sizeof(Datum) * total_messages);
+        int perm_fail_count = 0;
+        Datum *retry_fail_ids = palloc(sizeof(Datum) * total_messages);
+        Datum *retry_fail_retries = palloc(sizeof(Datum) * total_messages);
+        Datum *retry_fail_errors = palloc(sizeof(Datum) * total_messages);
+        Datum *retry_fail_delays = palloc(sizeof(Datum) * total_messages);
+        int retry_fail_count = 0;
+
+        /* Phase 1: Categorize messages into batch groups */
+        for (i = 0; i < total_messages; i++) {
+            if (all_messages[i].rate_limited) {
+                rate_limited_ids[rate_limited_count] = Int64GetDatum(all_messages[i].message_id);
+                rate_limited_delays[rate_limited_count] = Int32GetDatum(
+                    all_messages[i].rate_limit_defer_ms > 0 ? all_messages[i].rate_limit_defer_ms
+                                                            : 1000);
+                rate_limited_count++;
+                continue;
+            }
+
+            if (!all_messages[i].processed) {
+                /* Deferred rows were handled in the claim transaction; anything
+                 * else left unattempted goes back to pending right away. */
+                if (!all_messages[i].deferred) {
+                    rate_limited_ids[rate_limited_count] =
+                        Int64GetDatum(all_messages[i].message_id);
+                    rate_limited_delays[rate_limited_count] = Int32GetDatum(0);
+                    rate_limited_count++;
+                }
+                continue;
+            }
+
+            worker_update_stats_local(all_messages[i].success, all_messages[i].error_message);
+
+            if (all_messages[i].success) {
+                processed++;
+                if (all_messages[i].result && ulak_capture_response) {
+                    /* Response capture: individual UPDATE (unique response per msg) */
+                    ProtocolType proto_type;
+                    Jsonb *response_jsonb;
+                    if (!protocol_string_to_type(all_messages[i].protocol, &proto_type)) {
+                        elog(WARNING,
+                             "[ulak] Unknown protocol '%s' in response capture for "
+                             "message %lld",
+                             all_messages[i].protocol ? all_messages[i].protocol : "(null)",
+                             (long long)all_messages[i].message_id);
+                        proto_type = PROTOCOL_TYPE_HTTP;
+                    }
+                    response_jsonb = dispatch_result_to_jsonb(all_messages[i].result, proto_type);
+                    if (response_jsonb) {
+                        char *response_str =
+                            JsonbToCString(NULL, &response_jsonb->root, VARSIZE(response_jsonb));
+                        Oid argtypes[3] = {TEXTOID, TEXTOID, INT8OID};
+                        Datum values[3];
+                        char nulls[3] = {' ', ' ', ' '};
+                        values[0] = CStringGetTextDatum(STATUS_COMPLETED);
+                        values[1] = CStringGetTextDatum(response_str);
+                        values[2] = Int64GetDatum(all_messages[i].message_id);
+                        ret = SPI_execute_with_args(success_response_query, 3, argtypes, values,
+                                                    nulls, false, 0);
+                        if (ret != SPI_OK_UPDATE) {
+                            elog(WARNING,
+                                 "[ulak] Failed to update message %lld status: SPI "
+                                 "error %d",
+                                 (long long)all_messages[i].message_id, ret);
+                            failed_updates++;
+                        }
+                    } else {
+                        success_ids[success_count++] = Int64GetDatum(all_messages[i].message_id);
+                    }
+                } else {
+                    success_ids[success_count++] = Int64GetDatum(all_messages[i].message_id);
+                }
+            } else {
+                /* Categorize failed messages for batch UPDATE */
+                int max_retries = get_max_retries_from_policy(all_messages[i].retry_policy);
+                int delay_seconds = calculate_delay_from_policy(all_messages[i].retry_policy,
+                                                                all_messages[i].retry_count);
+                char *error_str =
+                    all_messages[i].error_message ? all_messages[i].error_message : "Unknown error";
+                bool is_permanent_error = (error_str && strncmp(error_str, ERROR_PREFIX_PERMANENT,
+                                                                ERROR_PREFIX_PERMANENT_LEN) == 0);
+
+                /* Retry-After override: use server-specified delay if available */
+                if (all_messages[i].result != NULL &&
+                    all_messages[i].result->retry_after_seconds > 0) {
+                    delay_seconds = all_messages[i].result->retry_after_seconds;
+                    elog(DEBUG1, "[ulak] Using Retry-After=%d for message %lld", delay_seconds,
+                         (long long)all_messages[i].message_id);
+                }
+
+                /* 410 Gone auto-disable: check error string for [DISABLE] marker */
+                if (error_str && strstr(error_str, ERROR_PREFIX_DISABLE) != NULL) {
+                    bool should_disable = false;
+
+                    /* Check endpoint config for auto_disable_on_gone (default: false) */
+                    if (all_messages[i].config != NULL) {
+                        JsonbValue val;
+                        if (extract_jsonb_value(all_messages[i].config, "auto_disable_on_gone",
+                                                &val) &&
+                            val.type == jbvBool && val.val.boolean) {
+                            should_disable = true;
+                        }
+                    }
+                    /* Also check DispatchResult flag (dispatch_ex path) */
+                    if (!should_disable && all_messages[i].result != NULL &&
+                        all_messages[i].result->should_disable_endpoint) {
+                        if (all_messages[i].config != NULL) {
+                            JsonbValue val;
+                            if (extract_jsonb_value(all_messages[i].config, "auto_disable_on_gone",
+                                                    &val) &&
+                                val.type == jbvBool && val.val.boolean) {
+                                should_disable = true;
+                            }
+                        }
+                    }
+
+                    if (should_disable) {
+                        static const char *disable_query =
+                            "UPDATE ulak.endpoints SET enabled = false, "
+                            "updated_at = NOW() WHERE id = $1 AND enabled = true";
+                        Oid dis_argtypes[1] = {INT8OID};
+                        Datum dis_values[1] = {Int64GetDatum(all_messages[i].endpoint_id)};
+                        char dis_nulls[1] = {' '};
+                        int dis_ret = SPI_execute_with_args(disable_query, 1, dis_argtypes,
+                                                            dis_values, dis_nulls, false, 0);
+                        if (dis_ret == SPI_OK_UPDATE && SPI_processed > 0) {
+                            elog(WARNING,
+                                 "[ulak] Auto-disabled endpoint %lld: "
+                                 "HTTP 410 Gone (auto_disable_on_gone=true)",
+                                 (long long)all_messages[i].endpoint_id);
+                        }
+                    }
+                }
+
+                if (is_permanent_error || all_messages[i].retry_count + 1 >= max_retries) {
+                    perm_fail_ids[perm_fail_count] = Int64GetDatum(all_messages[i].message_id);
+                    perm_fail_retries[perm_fail_count] =
+                        Int32GetDatum(all_messages[i].retry_count + 1);
+                    perm_fail_errors[perm_fail_count] = CStringGetTextDatum(error_str);
+                    perm_fail_count++;
+                } else {
+                    char delay_str[32];
+                    snprintf(delay_str, sizeof(delay_str), "%d", delay_seconds);
+                    retry_fail_ids[retry_fail_count] = Int64GetDatum(all_messages[i].message_id);
+                    retry_fail_retries[retry_fail_count] =
+                        Int32GetDatum(all_messages[i].retry_count + 1);
+                    retry_fail_errors[retry_fail_count] = CStringGetTextDatum(error_str);
+                    retry_fail_delays[retry_fail_count] = CStringGetTextDatum(delay_str);
+                    retry_fail_count++;
+                }
+            }
+
+            /* Circuit breaker: track last result per endpoint.
+             * We call update_circuit_breaker once per endpoint after the
+             * loop, avoiding N SPI calls for N messages to the same endpoint. */
+
+            /* Free DispatchResult if allocated */
+            if (all_messages[i].result != NULL) {
+                dispatch_result_free(all_messages[i].result);
+                all_messages[i].result = NULL;
+            }
+        }
+
+        /* Circuit breaker: one update per endpoint (last result wins) */
+        {
+            int64 last_ep_id = -1;
+            bool last_ep_success = false;
+
             for (i = 0; i < total_messages; i++) {
-                HeapTuple tuple = SPI_tuptable->vals[i];
-                bool isnull;
-                Jsonb *payload;
-                text *protocol_text;
-                Jsonb *config_jsonb;
-                Datum retry_policy_datum;
-                Datum payload_datum;
-                Datum protocol_datum;
-                Datum config_datum;
-
-                all_messages[i].message_id =
-                    DatumGetInt64(SPI_getbinval(tuple, tupdesc, 1, &isnull));
-                all_messages[i].endpoint_id =
-                    DatumGetInt64(SPI_getbinval(tuple, tupdesc, 2, &isnull));
-
-                payload_datum = SPI_getbinval(tuple, tupdesc, 3, &isnull);
-                if (isnull) {
-                    all_messages[i].payload_str = pstrdup("{}");
-                } else {
-                    payload = DatumGetJsonbP(payload_datum);
-                    all_messages[i].payload_str =
-                        JsonbToCString(NULL, &payload->root, VARSIZE(payload));
-                }
-
-                all_messages[i].retry_count =
-                    DatumGetInt32(SPI_getbinval(tuple, tupdesc, 4, &isnull));
-
-                /* Copy protocol string - must not be NULL */
-                protocol_datum = SPI_getbinval(tuple, tupdesc, 5, &isnull);
-                if (isnull) {
-                    elog(WARNING, "[ulak] NULL protocol for message %lld, skipping",
-                         (long long)all_messages[i].message_id);
-                    all_messages[i].protocol = NULL;
-                    all_messages[i].config = NULL;
-                    all_messages[i].processed = true;
-                    all_messages[i].success = false;
-                    all_messages[i].error_message = pstrdup("Endpoint protocol is NULL");
+                if (!all_messages[i].processed || all_messages[i].rate_limited)
                     continue;
-                }
-                protocol_text = DatumGetTextPP(protocol_datum);
-                all_messages[i].protocol = text_to_cstring(protocol_text);
-
-                /* Copy config JSONB - need to make a deep copy, must not be NULL */
-                config_datum = SPI_getbinval(tuple, tupdesc, 6, &isnull);
-                if (isnull) {
-                    elog(WARNING, "[ulak] NULL config for message %lld, skipping",
-                         (long long)all_messages[i].message_id);
-                    all_messages[i].config = NULL;
-                    all_messages[i].processed = true;
-                    all_messages[i].success = false;
-                    all_messages[i].error_message = pstrdup("Endpoint config is NULL");
-                    continue;
-                }
-                config_jsonb = DatumGetJsonbP(config_datum);
-                all_messages[i].config = (Jsonb *)palloc(VARSIZE(config_jsonb));
-                memcpy(all_messages[i].config, config_jsonb, VARSIZE(config_jsonb));
-
-                /* Copy retry_policy if present */
-                retry_policy_datum = SPI_getbinval(tuple, tupdesc, 7, &isnull);
-                if (!isnull) {
-                    Jsonb *rp = DatumGetJsonbP(retry_policy_datum);
-                    all_messages[i].retry_policy = (Jsonb *)palloc(VARSIZE(rp));
-                    memcpy(all_messages[i].retry_policy, rp, VARSIZE(rp));
-                } else {
-                    all_messages[i].retry_policy = NULL;
-                }
-
-                /* Extract additional fields */
-                /* Column 8: priority */
-                all_messages[i].priority = DatumGetInt16(SPI_getbinval(tuple, tupdesc, 8, &isnull));
-                if (isnull)
-                    all_messages[i].priority = 0;
-
-                /* Column 9: scheduled_at */
-                all_messages[i].scheduled_at =
-                    DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 9, &isnull));
-                if (isnull)
-                    all_messages[i].scheduled_at = 0;
-
-                /* Column 10: expires_at */
-                all_messages[i].expires_at =
-                    DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 10, &isnull));
-                if (isnull)
-                    all_messages[i].expires_at = 0;
-
-                /* Column 11: correlation_id (uuid as text) */
-                {
-                    Datum corr_datum = SPI_getbinval(tuple, tupdesc, 11, &isnull);
-                    if (!isnull) {
-                        /* UUID is typically returned as a type, convert to string */
-                        all_messages[i].correlation_id =
-                            DatumGetCString(DirectFunctionCall1(uuid_out, corr_datum));
-                    } else {
-                        all_messages[i].correlation_id = NULL;
-                    }
-                }
-
-                /* Column 12: endpoint enabled */
-                all_messages[i].endpoint_enabled =
-                    DatumGetBool(SPI_getbinval(tuple, tupdesc, 12, &isnull));
-                if (isnull)
-                    all_messages[i].endpoint_enabled = true;
-
-                /* Column 13: circuit_failure_count */
-                all_messages[i].endpoint_failure_count =
-                    DatumGetInt32(SPI_getbinval(tuple, tupdesc, 13, &isnull));
-                if (isnull)
-                    all_messages[i].endpoint_failure_count = 0;
-
-                /* Column 14: circuit_state (text) */
-                {
-                    Datum cs_datum = SPI_getbinval(tuple, tupdesc, 14, &isnull);
-                    if (!isnull) {
-                        text *cs_text = DatumGetTextPP(cs_datum);
-                        char *cs_str = text_to_cstring(cs_text);
-                        strlcpy(all_messages[i].circuit_state, cs_str,
-                                sizeof(all_messages[i].circuit_state));
-                        pfree(cs_str);
-                    } else {
-                        strlcpy(all_messages[i].circuit_state, "closed",
-                                sizeof(all_messages[i].circuit_state));
-                    }
-                }
-
-                /* Column 15: circuit_opened_at */
-                all_messages[i].circuit_opened_at =
-                    DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 15, &isnull));
-                if (isnull)
-                    all_messages[i].circuit_opened_at = 0;
-
-                /* Column 16: circuit_half_open_at */
-                all_messages[i].circuit_half_open_at =
-                    DatumGetTimestampTz(SPI_getbinval(tuple, tupdesc, 16, &isnull));
-                if (isnull)
-                    all_messages[i].circuit_half_open_at = 0;
-
-                /* Column 17: headers (jsonb, nullable) */
-                {
-                    Datum hdr_datum = SPI_getbinval(tuple, tupdesc, 17, &isnull);
-                    if (!isnull) {
-                        Jsonb *hdr = DatumGetJsonbP(hdr_datum);
-                        all_messages[i].headers = (Jsonb *)palloc(VARSIZE(hdr));
-                        memcpy(all_messages[i].headers, hdr, VARSIZE(hdr));
-                    } else {
-                        all_messages[i].headers = NULL;
-                    }
-                }
-
-                /* Column 18: metadata (jsonb, nullable) */
-                {
-                    Datum meta_datum = SPI_getbinval(tuple, tupdesc, 18, &isnull);
-                    if (!isnull) {
-                        Jsonb *meta = DatumGetJsonbP(meta_datum);
-                        all_messages[i].metadata = (Jsonb *)palloc(VARSIZE(meta));
-                        memcpy(all_messages[i].metadata, meta, VARSIZE(meta));
-                    } else {
-                        all_messages[i].metadata = NULL;
-                    }
-                }
-
-                all_messages[i].processed = false;
-                all_messages[i].success = false;
-                all_messages[i].error_message = NULL;
-                all_messages[i].result = NULL; /* Will be set during dispatch if capture_response */
-            }
-
-            /* Switch back to SPI context before executing queries */
-            MemoryContextSwitchTo(spi_context);
-
-            /* Mark all messages as processing — single batch UPDATE */
-            {
-                static const char *mark_processing_query =
-                    "UPDATE ulak.queue SET status = 'processing', "
-                    "processing_started_at = NOW() WHERE id = ANY($1::bigint[])";
-                Datum *mark_ids = palloc(sizeof(Datum) * total_messages);
-                ArrayType *mark_array;
-                Oid mark_argtypes[1] = {INT8ARRAYOID};
-                Datum mark_values[1];
-                char mark_nulls[1] = {' '};
-
-                for (i = 0; i < total_messages; i++)
-                    mark_ids[i] = Int64GetDatum(all_messages[i].message_id);
-
-                mark_array = construct_array(mark_ids, total_messages, INT8OID, sizeof(int64), true,
-                                             TYPALIGN_DOUBLE);
-                mark_values[0] = PointerGetDatum(mark_array);
-                ret = SPI_execute_with_args(mark_processing_query, 1, mark_argtypes, mark_values,
-                                            mark_nulls, false, 0);
-                if (ret != SPI_OK_UPDATE) {
-                    elog(WARNING,
-                         "[ulak] Failed to batch-mark %llu messages as processing: SPI error "
-                         "%d",
-                         (unsigned long long)total_messages, ret);
-                }
-                pfree(mark_ids);
-            }
-
-            /* Process messages grouped by endpoint (they're already ordered by endpoint_id) */
-            batch_start = 0;
-            while (batch_start < total_messages) {
-                /* Allow timely SIGTERM / SIGHUP handling between endpoint groups */
-                CHECK_FOR_INTERRUPTS();
-
-                current_endpoint_id = all_messages[batch_start].endpoint_id;
-                batch_end = batch_start;
-
-                /* Find all messages for this endpoint */
-                while (batch_end < total_messages &&
-                       all_messages[batch_end].endpoint_id == current_endpoint_id) {
-                    batch_end++;
-                }
-
-                batch_count = batch_end - batch_start;
-
-                /* Use protocol and config from the first message of this endpoint group */
-                protocol_str = all_messages[batch_start].protocol;
-                config = all_messages[batch_start].config;
-                retry_policy = all_messages[batch_start].retry_policy;
-
-                /*
-                 * Circuit breaker enforcement: skip dispatch if circuit is open.
-                 * When skipped, messages go back to pending with a retry delay
-                 * so they can be retried when the circuit transitions to half_open.
-                 * IMPORTANT: We do NOT call update_circuit_breaker for skipped messages
-                 * because no actual dispatch was attempted - otherwise the failure count
-                 * would keep increasing and the circuit would never recover.
-                 */
-                if (strcmp(all_messages[batch_start].circuit_state, "open") == 0) {
-                    uint64 k;
-
-                    /*
-                     * Check if cooldown has elapsed → transition to half_open.
-                     * half_open_at is set when CB opens: opened_at + cooldown.
-                     * If current time > half_open_at, allow one probe message through.
-                     */
-                    if (all_messages[batch_start].circuit_half_open_at > 0 &&
-                        GetCurrentTimestamp() >= all_messages[batch_start].circuit_half_open_at) {
-                        /* CAS-style transition: only one worker wins. Losers defer. */
-                        if (!cb_try_half_open_transition(current_endpoint_id)) {
-                            /* Another worker already transitioned — defer like open */
-                            uint64 m;
-                            for (m = batch_start; m < (uint64)batch_end; m++) {
-                                static const char *cb_lost_query =
-                                    "UPDATE ulak.queue SET status = 'pending', "
-                                    "processing_started_at = NULL, "
-                                    "next_retry_at = NOW() + '5 seconds'::interval, "
-                                    "last_error = 'Circuit breaker transition lost — "
-                                    "another worker is probing' "
-                                    "WHERE id = $1";
-                                SPI_execute_with_args(
-                                    cb_lost_query, 1, (Oid[]){INT8OID},
-                                    (Datum[]){Int64GetDatum(all_messages[m].message_id)}, NULL,
-                                    false, 0);
-                                all_messages[m].processed = false;
-                            }
-                            batch_start = batch_end;
-                            continue;
-                        }
-
-                        elog(LOG,
-                             "[ulak] Circuit breaker half_open for endpoint %lld — sending "
-                             "probe",
-                             (long long)current_endpoint_id);
-
-                        /* Let only the first message through as a probe, defer the rest */
-                        for (k = batch_start + 1; k < (uint64)batch_end; k++) {
-                            static const char *cb_defer_query =
-                                "UPDATE ulak.queue SET status = 'pending', "
-                                "processing_started_at = NULL, "
-                                "next_retry_at = NOW() + '5 seconds'::interval, "
-                                "last_error = 'Circuit breaker half_open - waiting for probe "
-                                "result' "
-                                "WHERE id = $1";
-                            Oid defer_argtypes[1] = {INT8OID};
-                            Datum defer_values[1];
-                            char defer_nulls[1] = {' '};
-                            defer_values[0] = Int64GetDatum(all_messages[k].message_id);
-                            SPI_execute_with_args(cb_defer_query, 1, defer_argtypes, defer_values,
-                                                  defer_nulls, false, 0);
-                            all_messages[k].processed = false;
-                        }
-                        /* Process only batch_start (probe message) */
-                        batch_end = batch_start + 1;
-                        batch_count = 1;
-                        /* Fall through to process_endpoint_batch with 1 message */
-                    } else {
-                        /*
-                         * Circuit is open and cooldown not elapsed: revert messages back
-                         * to pending with a retry delay.
-                         */
-                        for (k = batch_start; k < (uint64)batch_end; k++) {
-                            static const char *cb_defer_query =
-                                "UPDATE ulak.queue SET status = 'pending', "
-                                "processing_started_at = NULL, "
-                                "next_retry_at = NOW() + '10 seconds'::interval, "
-                                "last_error = 'Circuit breaker open - dispatch deferred' "
-                                "WHERE id = $1";
-                            Oid defer_argtypes[1] = {INT8OID};
-                            Datum defer_values[1];
-                            char defer_nulls[1] = {' '};
-                            defer_values[0] = Int64GetDatum(all_messages[k].message_id);
-                            SPI_execute_with_args(cb_defer_query, 1, defer_argtypes, defer_values,
-                                                  defer_nulls, false, 0);
-                            all_messages[k].processed = false;
-                        }
-                        elog(DEBUG1,
-                             "[ulak] Deferred %d messages for endpoint %lld: circuit breaker "
-                             "open",
-                             batch_count, (long long)current_endpoint_id);
-                        batch_start = batch_end;
-                        continue;
-                    }
-                }
-
-                /* Process this endpoint's batch */
-                process_endpoint_batch(&all_messages[batch_start], batch_count, protocol_str,
-                                       config, retry_policy);
-
-                batch_start = batch_end;
-            }
-
-            /* Update all message statuses — batch where possible, individual where needed.
-             * No string interpolation of user-derived values (especially error messages
-             * which may contain attacker-controlled content from HTTP responses). */
-            {
-                /* Batch queries */
-                static const char *batch_success_query =
-                    "UPDATE ulak.queue SET status = 'completed', last_error = NULL, "
-                    "completed_at = NOW(), updated_at = NOW() "
-                    "WHERE id = ANY($1::bigint[])";
-                static const char *batch_revert_query =
-                    "UPDATE ulak.queue q SET status = 'pending', "
-                    "processing_started_at = NULL, "
-                    "next_retry_at = NOW() + (v.defer_ms::text || ' milliseconds')::interval "
-                    "FROM (SELECT unnest($1::bigint[]) AS id, "
-                    "             unnest($2::int[]) AS defer_ms) v "
-                    "WHERE q.id = v.id";
-                static const char *batch_failed_query =
-                    "UPDATE ulak.queue q SET status = 'failed', "
-                    "retry_count = v.retry_count, last_error = v.last_error, "
-                    "failed_at = NOW() "
-                    "FROM (SELECT unnest($1::bigint[]) AS id, "
-                    "             unnest($2::int[]) AS retry_count, "
-                    "             unnest($3::text[]) AS last_error) v "
-                    "WHERE q.id = v.id";
-                static const char *batch_retry_query =
-                    "UPDATE ulak.queue q SET status = 'pending', "
-                    "retry_count = v.retry_count, last_error = v.last_error, "
-                    "next_retry_at = NOW() + (v.delay_seconds || ' seconds')::interval "
-                    "FROM (SELECT unnest($1::bigint[]) AS id, "
-                    "             unnest($2::int[]) AS retry_count, "
-                    "             unnest($3::text[]) AS last_error, "
-                    "             unnest($4::text[]) AS delay_seconds) v "
-                    "WHERE q.id = v.id";
-                static const char *batch_dlq_query = "SELECT ulak.archive_single_to_dlq(id) "
-                                                     "FROM unnest($1::bigint[]) AS id";
-                /* Individual query for response capture (unique per message) */
-                static const char *success_response_query =
-                    "UPDATE ulak.queue SET status = $1, last_error = NULL, "
-                    "completed_at = NOW(), response = $2::jsonb WHERE id = $3";
-                /* Batch collection arrays */
-                Datum *success_ids = palloc(sizeof(Datum) * total_messages);
-                int success_count = 0;
-                Datum *rate_limited_ids = palloc(sizeof(Datum) * total_messages);
-                Datum *rate_limited_delays = palloc(sizeof(Datum) * total_messages);
-                int rate_limited_count = 0;
-                Datum *perm_fail_ids = palloc(sizeof(Datum) * total_messages);
-                Datum *perm_fail_retries = palloc(sizeof(Datum) * total_messages);
-                Datum *perm_fail_errors = palloc(sizeof(Datum) * total_messages);
-                int perm_fail_count = 0;
-                Datum *retry_fail_ids = palloc(sizeof(Datum) * total_messages);
-                Datum *retry_fail_retries = palloc(sizeof(Datum) * total_messages);
-                Datum *retry_fail_errors = palloc(sizeof(Datum) * total_messages);
-                Datum *retry_fail_delays = palloc(sizeof(Datum) * total_messages);
-                int retry_fail_count = 0;
-
-                /* Phase 1: Categorize messages into batch groups */
-                for (i = 0; i < total_messages; i++) {
-                    if (all_messages[i].rate_limited) {
-                        rate_limited_ids[rate_limited_count] =
-                            Int64GetDatum(all_messages[i].message_id);
-                        rate_limited_delays[rate_limited_count] =
-                            Int32GetDatum(all_messages[i].rate_limit_defer_ms > 0
-                                              ? all_messages[i].rate_limit_defer_ms
-                                              : 1000);
-                        rate_limited_count++;
-                        continue;
-                    }
-
-                    if (!all_messages[i].processed)
-                        continue;
-
-                    worker_update_stats_local(all_messages[i].success,
-                                              all_messages[i].error_message);
-
-                    if (all_messages[i].success) {
-                        messages_processed++;
-                        if (all_messages[i].result && ulak_capture_response) {
-                            /* Response capture: individual UPDATE (unique response per msg) */
-                            ProtocolType proto_type;
-                            Jsonb *response_jsonb;
-                            if (!protocol_string_to_type(all_messages[i].protocol, &proto_type)) {
-                                elog(WARNING,
-                                     "[ulak] Unknown protocol '%s' in response capture for "
-                                     "message %lld",
-                                     all_messages[i].protocol ? all_messages[i].protocol : "(null)",
-                                     (long long)all_messages[i].message_id);
-                                proto_type = PROTOCOL_TYPE_HTTP;
-                            }
-                            response_jsonb =
-                                dispatch_result_to_jsonb(all_messages[i].result, proto_type);
-                            if (response_jsonb) {
-                                char *response_str = JsonbToCString(NULL, &response_jsonb->root,
-                                                                    VARSIZE(response_jsonb));
-                                Oid argtypes[3] = {TEXTOID, TEXTOID, INT8OID};
-                                Datum values[3];
-                                char nulls[3] = {' ', ' ', ' '};
-                                values[0] = CStringGetTextDatum(STATUS_COMPLETED);
-                                values[1] = CStringGetTextDatum(response_str);
-                                values[2] = Int64GetDatum(all_messages[i].message_id);
-                                ret = SPI_execute_with_args(success_response_query, 3, argtypes,
-                                                            values, nulls, false, 0);
-                                if (ret != SPI_OK_UPDATE) {
-                                    elog(WARNING,
-                                         "[ulak] Failed to update message %lld status: SPI "
-                                         "error %d",
-                                         (long long)all_messages[i].message_id, ret);
-                                    failed_updates++;
-                                }
-                            } else {
-                                success_ids[success_count++] =
-                                    Int64GetDatum(all_messages[i].message_id);
-                            }
-                        } else {
-                            success_ids[success_count++] =
-                                Int64GetDatum(all_messages[i].message_id);
-                        }
-                    } else {
-                        /* Categorize failed messages for batch UPDATE */
-                        int max_retries = get_max_retries_from_policy(all_messages[i].retry_policy);
-                        int delay_seconds = calculate_delay_from_policy(
-                            all_messages[i].retry_policy, all_messages[i].retry_count);
-                        char *error_str = all_messages[i].error_message
-                                              ? all_messages[i].error_message
-                                              : "Unknown error";
-                        bool is_permanent_error =
-                            (error_str && strncmp(error_str, ERROR_PREFIX_PERMANENT,
-                                                  ERROR_PREFIX_PERMANENT_LEN) == 0);
-
-                        /* Retry-After override: use server-specified delay if available */
-                        if (all_messages[i].result != NULL &&
-                            all_messages[i].result->retry_after_seconds > 0) {
-                            delay_seconds = all_messages[i].result->retry_after_seconds;
-                            elog(DEBUG1, "[ulak] Using Retry-After=%d for message %lld",
-                                 delay_seconds, (long long)all_messages[i].message_id);
-                        }
-
-                        /* 410 Gone auto-disable: check error string for [DISABLE] marker */
-                        if (error_str && strstr(error_str, ERROR_PREFIX_DISABLE) != NULL) {
-                            bool should_disable = false;
-
-                            /* Check endpoint config for auto_disable_on_gone (default: false) */
-                            if (all_messages[i].config != NULL) {
-                                JsonbValue val;
-                                if (extract_jsonb_value(all_messages[i].config,
-                                                        "auto_disable_on_gone", &val) &&
-                                    val.type == jbvBool && val.val.boolean) {
-                                    should_disable = true;
-                                }
-                            }
-                            /* Also check DispatchResult flag (dispatch_ex path) */
-                            if (!should_disable && all_messages[i].result != NULL &&
-                                all_messages[i].result->should_disable_endpoint) {
-                                if (all_messages[i].config != NULL) {
-                                    JsonbValue val;
-                                    if (extract_jsonb_value(all_messages[i].config,
-                                                            "auto_disable_on_gone", &val) &&
-                                        val.type == jbvBool && val.val.boolean) {
-                                        should_disable = true;
-                                    }
-                                }
-                            }
-
-                            if (should_disable) {
-                                static const char *disable_query =
-                                    "UPDATE ulak.endpoints SET enabled = false, "
-                                    "updated_at = NOW() WHERE id = $1 AND enabled = true";
-                                Oid dis_argtypes[1] = {INT8OID};
-                                Datum dis_values[1] = {Int64GetDatum(all_messages[i].endpoint_id)};
-                                char dis_nulls[1] = {' '};
-                                int dis_ret =
-                                    SPI_execute_with_args(disable_query, 1, dis_argtypes,
-                                                          dis_values, dis_nulls, false, 0);
-                                if (dis_ret == SPI_OK_UPDATE && SPI_processed > 0) {
-                                    elog(WARNING,
-                                         "[ulak] Auto-disabled endpoint %lld: "
-                                         "HTTP 410 Gone (auto_disable_on_gone=true)",
-                                         (long long)all_messages[i].endpoint_id);
-                                }
-                            }
-                        }
-
-                        if (is_permanent_error || all_messages[i].retry_count + 1 >= max_retries) {
-                            perm_fail_ids[perm_fail_count] =
-                                Int64GetDatum(all_messages[i].message_id);
-                            perm_fail_retries[perm_fail_count] =
-                                Int32GetDatum(all_messages[i].retry_count + 1);
-                            perm_fail_errors[perm_fail_count] = CStringGetTextDatum(error_str);
-                            perm_fail_count++;
-                        } else {
-                            char delay_str[32];
-                            snprintf(delay_str, sizeof(delay_str), "%d", delay_seconds);
-                            retry_fail_ids[retry_fail_count] =
-                                Int64GetDatum(all_messages[i].message_id);
-                            retry_fail_retries[retry_fail_count] =
-                                Int32GetDatum(all_messages[i].retry_count + 1);
-                            retry_fail_errors[retry_fail_count] = CStringGetTextDatum(error_str);
-                            retry_fail_delays[retry_fail_count] = CStringGetTextDatum(delay_str);
-                            retry_fail_count++;
-                        }
-                    }
-
-                    /* Circuit breaker: track last result per endpoint.
-                     * We call update_circuit_breaker once per endpoint after the
-                     * loop, avoiding N SPI calls for N messages to the same endpoint. */
-
-                    /* Free DispatchResult if allocated */
-                    if (all_messages[i].result != NULL) {
-                        dispatch_result_free(all_messages[i].result);
-                        all_messages[i].result = NULL;
-                    }
-                }
-
-                /* Circuit breaker: one update per endpoint (last result wins) */
-                {
-                    int64 last_ep_id = -1;
-                    bool last_ep_success = false;
-
-                    for (i = 0; i < total_messages; i++) {
-                        if (!all_messages[i].processed || all_messages[i].rate_limited)
-                            continue;
-                        /* Messages are ordered by endpoint_id, so track transitions */
-                        if (all_messages[i].endpoint_id != last_ep_id) {
-                            /* Flush previous endpoint's CB if any */
-                            if (last_ep_id >= 0)
-                                cb_update_after_dispatch(last_ep_id, last_ep_success);
-                            last_ep_id = all_messages[i].endpoint_id;
-                            last_ep_success = all_messages[i].success;
-                        } else {
-                            /* Same endpoint: if any message failed, mark as failed */
-                            if (!all_messages[i].success)
-                                last_ep_success = false;
-                        }
-                    }
-                    /* Flush last endpoint */
+                /* Messages are ordered by endpoint_id, so track transitions */
+                if (all_messages[i].endpoint_id != last_ep_id) {
+                    /* Flush previous endpoint's CB if any */
                     if (last_ep_id >= 0)
                         cb_update_after_dispatch(last_ep_id, last_ep_success);
+                    last_ep_id = all_messages[i].endpoint_id;
+                    last_ep_success = all_messages[i].success;
+                } else {
+                    /* Same endpoint: if any message failed, mark as failed */
+                    if (!all_messages[i].success)
+                        last_ep_success = false;
                 }
-
-                /* Phase 2: Execute batch UPDATEs */
-
-                /* Batch revert rate-limited messages (deferred by ~1 token interval) */
-                if (rate_limited_count > 0) {
-                    ArrayType *id_array =
-                        construct_array(rate_limited_ids, rate_limited_count, INT8OID,
-                                        sizeof(int64), true, TYPALIGN_DOUBLE);
-                    ArrayType *delay_array =
-                        construct_array(rate_limited_delays, rate_limited_count, INT4OID,
-                                        sizeof(int32), true, TYPALIGN_INT);
-                    Oid argtypes[2] = {INT8ARRAYOID, INT4ARRAYOID};
-                    Datum values[2] = {PointerGetDatum(id_array), PointerGetDatum(delay_array)};
-                    char nulls[2] = {' ', ' '};
-                    ret = SPI_execute_with_args(batch_revert_query, 2, argtypes, values, nulls,
-                                                false, 0);
-                    if (ret != SPI_OK_UPDATE) {
-                        elog(WARNING, "[ulak] Batch revert rate-limited failed: SPI error %d", ret);
-                    }
-                }
-
-                /* Batch success UPDATE */
-                if (success_count > 0) {
-                    ArrayType *id_array = construct_array(success_ids, success_count, INT8OID,
-                                                          sizeof(int64), true, TYPALIGN_DOUBLE);
-                    Oid argtypes[1] = {INT8ARRAYOID};
-                    Datum values[1] = {PointerGetDatum(id_array)};
-                    char nulls[1] = {' '};
-                    ret = SPI_execute_with_args(batch_success_query, 1, argtypes, values, nulls,
-                                                false, 0);
-                    if (ret != SPI_OK_UPDATE) {
-                        elog(WARNING, "[ulak] Batch success UPDATE failed: SPI error %d", ret);
-                        failed_updates += success_count;
-                    }
-                }
-
-                /* Batch permanent failure UPDATE + DLQ archive */
-                if (perm_fail_count > 0) {
-                    ArrayType *id_array = construct_array(perm_fail_ids, perm_fail_count, INT8OID,
-                                                          sizeof(int64), true, TYPALIGN_DOUBLE);
-                    ArrayType *retry_array =
-                        construct_array(perm_fail_retries, perm_fail_count, INT4OID, sizeof(int32),
-                                        true, TYPALIGN_INT);
-                    ArrayType *error_array = construct_array(perm_fail_errors, perm_fail_count,
-                                                             TEXTOID, -1, false, TYPALIGN_INT);
-                    Oid argtypes[3] = {INT8ARRAYOID, INT4ARRAYOID, TEXTARRAYOID};
-                    Datum values[3] = {PointerGetDatum(id_array), PointerGetDatum(retry_array),
-                                       PointerGetDatum(error_array)};
-                    char nulls[3] = {' ', ' ', ' '};
-                    ret = SPI_execute_with_args(batch_failed_query, 3, argtypes, values, nulls,
-                                                false, 0);
-                    if (ret != SPI_OK_UPDATE) {
-                        elog(WARNING, "[ulak] Batch permanent failure UPDATE failed: SPI error %d",
-                             ret);
-                        failed_updates += perm_fail_count;
-                    }
-
-                    /* Batch DLQ archive */
-                    {
-                        Oid dlq_argtypes[1] = {INT8ARRAYOID};
-                        Datum dlq_values[1] = {PointerGetDatum(id_array)};
-                        char dlq_nulls[1] = {' '};
-                        int dlq_ret = SPI_execute_with_args(batch_dlq_query, 1, dlq_argtypes,
-                                                            dlq_values, dlq_nulls, false, 0);
-                        if (dlq_ret != SPI_OK_SELECT) {
-                            elog(WARNING, "[ulak] Batch DLQ archive failed: SPI error %d", dlq_ret);
-                        }
-                    }
-                }
-
-                /* Batch retryable failure UPDATE */
-                if (retry_fail_count > 0) {
-                    ArrayType *id_array = construct_array(retry_fail_ids, retry_fail_count, INT8OID,
-                                                          sizeof(int64), true, TYPALIGN_DOUBLE);
-                    ArrayType *retry_array =
-                        construct_array(retry_fail_retries, retry_fail_count, INT4OID,
-                                        sizeof(int32), true, TYPALIGN_INT);
-                    ArrayType *error_array = construct_array(retry_fail_errors, retry_fail_count,
-                                                             TEXTOID, -1, false, TYPALIGN_INT);
-                    ArrayType *delay_array = construct_array(retry_fail_delays, retry_fail_count,
-                                                             TEXTOID, -1, false, TYPALIGN_INT);
-                    Oid argtypes[4] = {INT8ARRAYOID, INT4ARRAYOID, TEXTARRAYOID, TEXTARRAYOID};
-                    Datum values[4] = {PointerGetDatum(id_array), PointerGetDatum(retry_array),
-                                       PointerGetDatum(error_array), PointerGetDatum(delay_array)};
-                    char nulls[4] = {' ', ' ', ' ', ' '};
-                    ret = SPI_execute_with_args(batch_retry_query, 4, argtypes, values, nulls,
-                                                false, 0);
-                    if (ret != SPI_OK_UPDATE) {
-                        elog(WARNING, "[ulak] Batch retry failure UPDATE failed: SPI error %d",
-                             ret);
-                        failed_updates += retry_fail_count;
-                    }
-                }
-
-                pfree(success_ids);
-                pfree(rate_limited_ids);
-                pfree(rate_limited_delays);
-                pfree(perm_fail_ids);
-                pfree(perm_fail_retries);
-                pfree(perm_fail_errors);
-                pfree(retry_fail_ids);
-                pfree(retry_fail_retries);
-                pfree(retry_fail_errors);
-                pfree(retry_fail_delays);
-
-                /*
-                 * If any status updates failed, abort the transaction to prevent
-                 * messages from being stuck in 'processing' state forever.
-                 * Messages will be re-fetched and re-processed on the next cycle.
-                 * This is safe because ulak consumers should be idempotent.
-                 */
-                if (failed_updates > 0) {
-                    elog(WARNING,
-                         "[ulak] %d message status update(s) failed, aborting batch to "
-                         "prevent stuck "
-                         "messages",
-                         failed_updates);
-                    PopActiveSnapshot();
-                    SPI_finish();
-                    AbortCurrentTransaction();
-                    if (batch_context)
-                        MemoryContextSwitchTo(old_context);
-                    if (batch_context) {
-                        MemoryContextDelete(batch_context);
-                        worker_batch_context = NULL;
-                    }
-                    return 0;
-                }
-
-                if (messages_processed > 0)
-                    elog(DEBUG1, "[ulak] Processed %lld/%lu messages in this batch",
-                         (long long)messages_processed, (unsigned long)total_messages);
             }
-
-            fetched_count = (int64)total_messages;
-        } else if (ret != SPI_OK_SELECT) {
-            elog(WARNING, "[ulak] Failed to query pending messages: SPI error %d", ret);
+            /* Flush last endpoint */
+            if (last_ep_id >= 0)
+                cb_update_after_dispatch(last_ep_id, last_ep_success);
         }
 
-        MemoryContextSwitchTo(spi_context);
-        PopActiveSnapshot();
-        SPI_finish();
-        CommitTransactionCommand();
+        /* Phase 2: Execute batch UPDATEs */
 
-        /* Flush stats AFTER successful commit to avoid phantom metrics */
-        worker_flush_stats_to_shmem(worker_dboid, worker_id);
+        /* Batch revert rate-limited messages (deferred by ~1 token interval) */
+        if (rate_limited_count > 0) {
+            ArrayType *id_array = construct_array(rate_limited_ids, rate_limited_count, INT8OID,
+                                                  sizeof(int64), true, TYPALIGN_DOUBLE);
+            ArrayType *delay_array = construct_array(rate_limited_delays, rate_limited_count,
+                                                     INT4OID, sizeof(int32), true, TYPALIGN_INT);
+            Oid argtypes[2] = {INT8ARRAYOID, INT4ARRAYOID};
+            Datum values[2] = {PointerGetDatum(id_array), PointerGetDatum(delay_array)};
+            char nulls[2] = {' ', ' '};
+            ret = SPI_execute_with_args(batch_revert_query, 2, argtypes, values, nulls, false, 0);
+            if (ret != SPI_OK_UPDATE) {
+                elog(WARNING, "[ulak] Batch revert rate-limited failed: SPI error %d", ret);
+            }
+        }
 
-        /* Destroy batch context — frees all batch allocations automatically */
+        /* Batch success UPDATE */
+        if (success_count > 0) {
+            ArrayType *id_array = construct_array(success_ids, success_count, INT8OID,
+                                                  sizeof(int64), true, TYPALIGN_DOUBLE);
+            Oid argtypes[1] = {INT8ARRAYOID};
+            Datum values[1] = {PointerGetDatum(id_array)};
+            char nulls[1] = {' '};
+            ret = SPI_execute_with_args(batch_success_query, 1, argtypes, values, nulls, false, 0);
+            if (ret != SPI_OK_UPDATE) {
+                elog(WARNING, "[ulak] Batch success UPDATE failed: SPI error %d", ret);
+                failed_updates += success_count;
+            }
+        }
+
+        /* Batch permanent failure UPDATE + DLQ archive */
+        if (perm_fail_count > 0) {
+            ArrayType *id_array = construct_array(perm_fail_ids, perm_fail_count, INT8OID,
+                                                  sizeof(int64), true, TYPALIGN_DOUBLE);
+            ArrayType *retry_array = construct_array(perm_fail_retries, perm_fail_count, INT4OID,
+                                                     sizeof(int32), true, TYPALIGN_INT);
+            ArrayType *error_array = construct_array(perm_fail_errors, perm_fail_count, TEXTOID, -1,
+                                                     false, TYPALIGN_INT);
+            Oid argtypes[3] = {INT8ARRAYOID, INT4ARRAYOID, TEXTARRAYOID};
+            Datum values[3] = {PointerGetDatum(id_array), PointerGetDatum(retry_array),
+                               PointerGetDatum(error_array)};
+            char nulls[3] = {' ', ' ', ' '};
+            ret = SPI_execute_with_args(batch_failed_query, 3, argtypes, values, nulls, false, 0);
+            if (ret != SPI_OK_UPDATE_RETURNING) {
+                elog(WARNING, "[ulak] Batch permanent failure UPDATE failed: SPI error %d", ret);
+                failed_updates += perm_fail_count;
+            } else if (SPI_processed > 0 && SPI_tuptable != NULL) {
+                /* Archive exactly the rows the UPDATE marked failed (still ours) */
+                uint64 n = SPI_processed;
+                Datum *dlq_ids = palloc(sizeof(Datum) * n);
+                ArrayType *dlq_array;
+                uint64 r;
+                int dlq_ret;
+
+                for (r = 0; r < n; r++) {
+                    bool id_null;
+                    dlq_ids[r] =
+                        SPI_getbinval(SPI_tuptable->vals[r], SPI_tuptable->tupdesc, 1, &id_null);
+                }
+                dlq_array =
+                    construct_array(dlq_ids, n, INT8OID, sizeof(int64), true, TYPALIGN_DOUBLE);
+                dlq_ret =
+                    SPI_execute_with_args(batch_dlq_query, 1, (Oid[]){INT8ARRAYOID},
+                                          (Datum[]){PointerGetDatum(dlq_array)}, NULL, false, 0);
+                if (dlq_ret != SPI_OK_SELECT)
+                    elog(WARNING, "[ulak] Batch DLQ archive failed: SPI error %d", dlq_ret);
+                pfree(dlq_ids);
+            }
+        }
+
+        /* Batch retryable failure UPDATE */
+        if (retry_fail_count > 0) {
+            ArrayType *id_array = construct_array(retry_fail_ids, retry_fail_count, INT8OID,
+                                                  sizeof(int64), true, TYPALIGN_DOUBLE);
+            ArrayType *retry_array = construct_array(retry_fail_retries, retry_fail_count, INT4OID,
+                                                     sizeof(int32), true, TYPALIGN_INT);
+            ArrayType *error_array = construct_array(retry_fail_errors, retry_fail_count, TEXTOID,
+                                                     -1, false, TYPALIGN_INT);
+            ArrayType *delay_array = construct_array(retry_fail_delays, retry_fail_count, TEXTOID,
+                                                     -1, false, TYPALIGN_INT);
+            Oid argtypes[4] = {INT8ARRAYOID, INT4ARRAYOID, TEXTARRAYOID, TEXTARRAYOID};
+            Datum values[4] = {PointerGetDatum(id_array), PointerGetDatum(retry_array),
+                               PointerGetDatum(error_array), PointerGetDatum(delay_array)};
+            char nulls[4] = {' ', ' ', ' ', ' '};
+            ret = SPI_execute_with_args(batch_retry_query, 4, argtypes, values, nulls, false, 0);
+            if (ret != SPI_OK_UPDATE) {
+                elog(WARNING, "[ulak] Batch retry failure UPDATE failed: SPI error %d", ret);
+                failed_updates += retry_fail_count;
+            }
+        }
+
+        pfree(success_ids);
+        pfree(rate_limited_ids);
+        pfree(rate_limited_delays);
+        pfree(perm_fail_ids);
+        pfree(perm_fail_retries);
+        pfree(perm_fail_errors);
+        pfree(retry_fail_ids);
+        pfree(retry_fail_retries);
+        pfree(retry_fail_errors);
+        pfree(retry_fail_delays);
+
+        /*
+         * If any status update failed, abort so that no partial result is
+         * committed. The rows are still 'processing' from the claim
+         * transaction; the caller releases them back to 'pending' so they are
+         * re-fetched on the next cycle (consumers are idempotent).
+         */
+        if (failed_updates > 0) {
+            elog(WARNING,
+                 "[ulak] %d message status update(s) failed, aborting result "
+                 "transaction and releasing the batch",
+                 failed_updates);
+            PopActiveSnapshot();
+            SPI_finish();
+            AbortCurrentTransaction();
+            return false;
+        }
+
+        if (processed > 0)
+            elog(DEBUG1, "[ulak] Processed %lld/%lu messages in this batch", (long long)processed,
+                 (unsigned long)total_messages);
+    }
+
+    PopActiveSnapshot();
+    SPI_finish();
+    CommitTransactionCommand();
+    MemoryContextSwitchTo(caller_context);
+
+    *messages_processed = processed;
+    return true;
+}
+
+int64 batch_processor_run(Oid worker_dboid, int worker_id, int total_workers) {
+    MemoryContext caller_context = CurrentMemoryContext;
+    MemoryContext batch_context;
+    MessageBatchInfo *all_messages = NULL;
+    uint64 total_messages = 0;
+    int64 messages_processed = 0;
+
+    /*
+     * batch_context is a child of TopMemoryContext: it must outlive the
+     * claim transaction because the copied rows are delivered after it
+     * commits. It is deleted at the end of the batch (or from
+     * batch_processor_cleanup_on_error).
+     */
+    batch_context = AllocSetContextCreate(TopMemoryContext, "ulak batch", ALLOCSET_DEFAULT_SIZES);
+    worker_batch_context = batch_context;
+
+    /* Phase 1: claim + commit */
+    if (!batch_claim(worker_id, total_workers, batch_context, &all_messages, &total_messages) ||
+        total_messages == 0) {
+        MemoryContextSwitchTo(caller_context);
         MemoryContextDelete(batch_context);
         worker_batch_context = NULL;
-
-        return fetched_count;
+        return 0;
     }
+    in_flight.messages = all_messages;
+    in_flight.count = total_messages;
+    in_flight.claimed = true;
+    batch_last_heartbeat = GetCurrentTimestamp();
+
+    /* Phase 2: deliver, no transaction open */
+    MemoryContextSwitchTo(batch_context);
+    batch_deliver(all_messages, total_messages);
+    MemoryContextSwitchTo(caller_context);
+
+    /* Phase 3: write results; on failure release the rows right away */
+    if (batch_write_results(all_messages, total_messages, &messages_processed)) {
+        /* Flush stats only after the commit to avoid phantom metrics */
+        worker_flush_stats_to_shmem(worker_dboid, worker_id);
+    } else {
+        batch_release_claimed_rows(all_messages, total_messages);
+        /* Nothing was recorded; drop the counters this batch accumulated */
+        worker_local_stats.messages_processed = 0;
+        worker_local_stats.error_count = 0;
+        worker_local_stats.has_error = false;
+        worker_local_stats.last_error_msg[0] = '\0';
+    }
+
+    in_flight.messages = NULL;
+    in_flight.count = 0;
+    in_flight.claimed = false;
+    batch_last_heartbeat = 0;
+
+    MemoryContextSwitchTo(caller_context);
+    MemoryContextDelete(batch_context);
+    worker_batch_context = NULL;
+
+    return (int64)total_messages;
 }

--- a/src/worker/batch_processor.h
+++ b/src/worker/batch_processor.h
@@ -37,4 +37,15 @@ extern int64 batch_processor_run(Oid worker_dboid, int worker_id, int total_work
  */
 extern void batch_processor_cleanup_on_error(void);
 
+/**
+ * @brief Return the rows claimed by an interrupted batch to 'pending'.
+ *
+ * The claim transaction commits before delivery starts, so an error raised
+ * during delivery or while writing results leaves the rows 'processing'.
+ * Call from the worker's PG_CATCH after the failed transaction has been
+ * aborted and before batch_processor_cleanup_on_error(); it runs its own
+ * short transaction and is a no-op when no batch is in flight.
+ */
+extern void batch_processor_release_claimed(void);
+
 #endif /* ULAK_WORKER_BATCH_PROCESSOR_H */

--- a/src/worker/batch_types.h
+++ b/src/worker/batch_types.h
@@ -43,6 +43,7 @@ typedef struct {
     DispatchResult *result;    /* Dispatch result for response capture */
     Jsonb *headers;            /* Per-message headers */
     Jsonb *metadata;           /* Per-message metadata */
+    bool deferred;             /* Put back to pending by the circuit breaker — skip dispatch */
     bool rate_limited;         /* Deferred by rate limiter — skip dispatch */
     int32 rate_limit_defer_ms; /* How long to defer a rate-limited message (next_retry_at) */
 } MessageBatchInfo;

--- a/src/worker/circuit_breaker.h
+++ b/src/worker/circuit_breaker.h
@@ -7,8 +7,8 @@
  * (ulak.endpoints.circuit_state, ulak.update_circuit_breaker()).
  *
  * The in-loop decision logic (skip vs. half-open probe vs. dispatch)
- * still lives inside process_pending_messages_batch() in worker.c and
- * will be migrated with the rest of the batch processor.
+ * lives in batch_claim() in batch_processor.c and runs inside the claim
+ * transaction; cb_update_after_dispatch() runs in the result transaction.
  */
 
 #ifndef ULAK_WORKER_CIRCUIT_BREAKER_H

--- a/t/004_wake_latency.pl
+++ b/t/004_wake_latency.pl
@@ -1,0 +1,76 @@
+# Test: senders wake the delivery workers at commit through shared memory
+#
+# With ulak.poll_interval at its maximum (60 s) a message can only be
+# attempted quickly if the committing backend woke the worker itself
+# (src/wake.c). Two messages land on two different workers (id-based
+# partitioning), so both latches must be set. Also checks that a message can
+# be sent inside a prepared transaction, which NOTIFY used to forbid.
+
+use strict;
+use warnings;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More tests => 5;
+use Time::HiRes qw(time);
+
+my $node = PostgreSQL::Test::Cluster->new('primary');
+$node->init;
+$node->append_conf('postgresql.conf', qq{
+shared_preload_libraries = 'ulak'
+ulak.database = 'postgres'
+ulak.workers = 2
+ulak.poll_interval = 60000
+ulak.http_allow_internal_urls = on
+ulak.http_connect_timeout = 1
+max_prepared_transactions = 2
+});
+$node->start;
+
+$node->safe_psql('postgres', 'CREATE EXTENSION ulak');
+
+$node->poll_query_until('postgres',
+    "SELECT count(*) = 2 FROM pg_stat_activity WHERE backend_type LIKE '%ulak%'")
+    or BAIL_OUT('Workers did not start');
+
+is($node->safe_psql('postgres', 'SHOW ulak.wake_notify'), 'off',
+    'NOTIFY is off by default: workers are woken through shared memory');
+
+# Nothing to do: both workers go to sleep for the full 60 s poll interval.
+sleep 3;
+
+# Unreachable target: the first attempt fails fast with a connection error,
+# which is enough to prove the worker woke up (retry_count becomes 1).
+$node->safe_psql('postgres', q{
+    INSERT INTO ulak.endpoints (name, protocol, config)
+    VALUES ('wake_ep', 'http', '{"url": "http://127.0.0.1:1/wake"}'::jsonb)
+});
+
+my $t0 = time();
+$node->safe_psql('postgres', q{
+    SELECT ulak.send('wake_ep', '{"n": 1}'::jsonb);
+    SELECT ulak.send('wake_ep', '{"n": 2}'::jsonb);
+});
+$node->poll_query_until('postgres',
+    "SELECT count(*) = 2 FROM ulak.queue WHERE retry_count > 0 OR status <> 'pending'")
+    or BAIL_OUT('Messages were never attempted');
+my $elapsed = time() - $t0;
+ok($elapsed < 10,
+    sprintf('both partitions attempted delivery %.1fs after commit (poll interval is 60 s)', $elapsed));
+
+my $partitions = $node->safe_psql('postgres',
+    "SELECT count(DISTINCT id % 2) FROM ulak.queue");
+is($partitions, '2', 'the two messages belong to two different partitions');
+
+# A prepared transaction: NOTIFY would have refused PREPARE TRANSACTION.
+$node->safe_psql('postgres', q{
+    BEGIN;
+    SELECT ulak.send('wake_ep', '{"n": 3}'::jsonb);
+    PREPARE TRANSACTION 'ulak_wake';
+});
+is($node->safe_psql('postgres', "SELECT count(*) FROM pg_prepared_xacts WHERE gid = 'ulak_wake'"),
+    '1', 'a transaction that queued a message can be prepared');
+$node->safe_psql('postgres', "COMMIT PREPARED 'ulak_wake'");
+is($node->safe_psql('postgres', "SELECT count(*) FROM ulak.queue WHERE payload->>'n' = '3'"),
+    '1', 'the prepared message is in the queue after COMMIT PREPARED');
+
+$node->stop;

--- a/t/005_claim_before_delivery.pl
+++ b/t/005_claim_before_delivery.pl
@@ -1,0 +1,77 @@
+# Test: the claim commits before delivery starts
+#
+# A listener that accepts the TCP connection but never answers keeps the
+# HTTP dispatcher busy until ulak.http_timeout. While it hangs, the row must
+# be visible as 'processing' from another session and no worker may hold an
+# open transaction, xid, snapshot or lock (the old design held all of them for
+# the whole delivery). When the listener goes away the row is retried.
+
+use strict;
+use warnings;
+use IO::Socket::INET;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More tests => 6;
+
+my $listener = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1', LocalPort => 0, Proto => 'tcp', Listen => 5, ReuseAddr => 1)
+    or BAIL_OUT("cannot open a local listener: $!");
+my $port = $listener->sockport;
+
+my $node = PostgreSQL::Test::Cluster->new('primary');
+$node->init;
+$node->append_conf('postgresql.conf', qq{
+shared_preload_libraries = 'ulak'
+ulak.database = 'postgres'
+ulak.workers = 1
+ulak.poll_interval = 200
+ulak.http_allow_internal_urls = on
+ulak.http_connect_timeout = 5
+ulak.http_timeout = 20
+});
+$node->start;
+$node->safe_psql('postgres', 'CREATE EXTENSION ulak');
+$node->poll_query_until('postgres',
+    "SELECT count(*) > 0 FROM pg_stat_activity WHERE backend_type LIKE '%ulak%'")
+    or BAIL_OUT('Worker did not start');
+
+$node->safe_psql('postgres', qq{
+    INSERT INTO ulak.endpoints (name, protocol, config)
+    VALUES ('hang_ep', 'http', '{"url": "http://127.0.0.1:$port/hang"}'::jsonb)
+});
+my $id = $node->safe_psql('postgres',
+    q{SELECT ulak.send_with_options('hang_ep', '{"n": 1}'::jsonb)});
+
+# The worker connects (kernel backlog accepts it) and then waits for a response.
+$node->poll_query_until('postgres',
+    "SELECT status = 'processing' FROM ulak.queue WHERE id = $id")
+    or BAIL_OUT('row never became processing');
+pass('row is visible as processing from another session while delivery is in flight');
+
+sleep 2;
+is($node->safe_psql('postgres',
+        "SELECT status FROM ulak.queue WHERE id = $id"),
+    'processing', 'still processing two seconds into the hung delivery');
+
+my $worker_state = $node->safe_psql('postgres', q{
+    SELECT count(*) FILTER (WHERE xact_start IS NOT NULL) || ' ' ||
+           count(*) FILTER (WHERE backend_xid IS NOT NULL) || ' ' ||
+           count(*) FILTER (WHERE backend_xmin IS NOT NULL)
+    FROM pg_stat_activity WHERE backend_type LIKE '%ulak%'});
+is($worker_state, '0 0 0', 'no worker holds a transaction, xid or snapshot during delivery');
+
+my $locks = $node->safe_psql('postgres', q{
+    SELECT count(*) FROM pg_locks l JOIN pg_stat_activity a ON a.pid = l.pid
+    WHERE a.backend_type LIKE '%ulak%' AND l.locktype NOT IN ('relation', 'virtualxid')});
+is($locks, '0', 'no worker holds row or transaction locks during delivery');
+
+# Drop the listener: the pending connection is reset and the delivery fails fast.
+close($listener);
+$node->poll_query_until('postgres',
+    "SELECT retry_count = 1 AND status = 'pending' FROM ulak.queue WHERE id = $id")
+    or BAIL_OUT('row was not retried after the listener went away');
+pass('row went back to pending with one retry recorded');
+like($node->safe_psql('postgres', "SELECT last_error FROM ulak.queue WHERE id = $id"),
+    qr/RETRYABLE/, 'the failure is classified as retryable');
+
+$node->stop;

--- a/tests/e2e/amqp-tests.sh
+++ b/tests/e2e/amqp-tests.sh
@@ -22,8 +22,10 @@ rabbit_cmd() {
 rabbit_declare_queue() {
   local queue="$1"
   # Declare queue via rabbitmqadmin (management plugin)
-  docker exec ulak-rabbitmq-1 rabbitmqadmin declare queue name="$queue" durable=false 2>/dev/null || \
-    rabbit_cmd eval "rabbit_amqqueue:declare(rabbit_misc:r(<<\"/\">>, queue, <<\"$queue\">>), false, false, [], none, <<\"guest\">>)." 2>/dev/null || true
+  # durable=true: RabbitMQ 4 refuses transient non-exclusive queues by default
+  # (deprecated feature transient_nonexcl_queues); ulak itself declares no queues.
+  docker exec ulak-rabbitmq-1 rabbitmqadmin declare queue name="$queue" durable=true 2>/dev/null || \
+    rabbit_cmd eval "rabbit_amqqueue:declare(rabbit_misc:r(<<\"/\">>, queue, <<\"$queue\">>), true, false, [], none, <<\"guest\">>)." 2>/dev/null || true
 }
 
 rabbit_queue_messages() {
@@ -219,10 +221,16 @@ psql_quiet "DELETE FROM ulak.dlq;"
 create_endpoint "at-err" "{\"host\": \"nonexistent-host\", \"exchange\": \"e\", \"routing_key\": \"r\", \"username\": \"guest\", \"password\": \"guest\"}" "amqp"
 send_msg "at-err" "{\"should_fail\": true}"
 
-sleep 20
+# The row is claimed ('processing') at once; wait for the retry to be
+# recorded instead of sampling at a fixed moment.
+ERROR=""
+for _ in $(seq 1 45); do
+  ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'at-err') LIMIT 1;")
+  [ -n "$ERROR" ] && break
+  sleep 1
+done
 
 STATUS=$(psql_exec "SELECT status FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'at-err') LIMIT 1;")
-ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'at-err') LIMIT 1;")
 
 assert_eq "Failed message pending (retryable)" "pending" "$STATUS"
 assert_contains "Error has RETRYABLE prefix" "RETRYABLE" "$ERROR"

--- a/tests/e2e/kafka-tests.sh
+++ b/tests/e2e/kafka-tests.sh
@@ -293,11 +293,19 @@ psql_quiet "DELETE FROM ulak.dlq;"
 create_endpoint "kt-err" "{\"broker\": \"nonexistent:9092\", \"topic\": \"kt-err\"}" "kafka"
 
 send_msg "kt-err" "{\"should_fail\": true}"
-sleep 20
 
-# Should be in pending/retry state (retryable error)
+# The row is claimed ('processing') at once and stays so until librdkafka gives
+# up after ulak.kafka_delivery_timeout (30 s by default); wait for the retry to
+# be recorded instead of sampling at a fixed moment.
+ERROR=""
+for _ in $(seq 1 50); do
+  ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'kt-err') LIMIT 1;")
+  [ -n "$ERROR" ] && break
+  sleep 1
+done
+
+# Should be back in pending with a retry scheduled (retryable error)
 STATUS=$(psql_exec "SELECT status FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'kt-err') LIMIT 1;")
-ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'kt-err') LIMIT 1;")
 echo "  last_error: $(psql_exec "SELECT left(last_error, 120) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'kt-err') LIMIT 1;")"
 
 assert_eq "Failed message still pending (retryable)" "pending" "$STATUS"

--- a/tests/e2e/redis-tests.sh
+++ b/tests/e2e/redis-tests.sh
@@ -238,10 +238,16 @@ psql_quiet "DELETE FROM ulak.dlq;"
 create_endpoint "rt-err" "{\"host\": \"nonexistent-host\", \"stream_key\": \"rt-err\"}" "redis"
 send_msg "rt-err" "{\"should_fail\": true}"
 
-sleep 10
+# Name resolution is bounded by connect_timeout (5 s default); wait for the
+# retry to be recorded rather than sampling at a fixed moment.
+ERROR=""
+for _ in $(seq 1 30); do
+  ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'rt-err') LIMIT 1;")
+  [ -n "$ERROR" ] && break
+  sleep 1
+done
 
 STATUS=$(psql_exec "SELECT status FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'rt-err') LIMIT 1;")
-ERROR=$(psql_exec "SELECT left(last_error, 12) FROM ulak.queue WHERE endpoint_id = (SELECT id FROM ulak.endpoints WHERE name = 'rt-err') LIMIT 1;")
 
 assert_eq "Failed message pending (retryable)" "pending" "$STATUS"
 assert_contains "Error has RETRYABLE prefix" "RETRYABLE" "$ERROR"

--- a/tests/regress/expected/00_setup.out
+++ b/tests/regress/expected/00_setup.out
@@ -10,6 +10,9 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+-- The reload reaches this backend asynchronously (SIGHUP relayed by the
+-- postmaster); set it for this session too so the endpoint below never races it.
+SET ulak.http_allow_internal_urls = true;
 -- Verify extension is installed
 SELECT extname, extversion IS NOT NULL AS has_version FROM pg_extension WHERE extname = 'ulak';
  extname | has_version 

--- a/tests/regress/expected/01_schema.out
+++ b/tests/regress/expected/01_schema.out
@@ -107,6 +107,7 @@ ORDER BY p.proname;
  _active_queue_count            | p_reserve bigint DEFAULT 0
  _check_backpressure            | p_projected_additional bigint DEFAULT 0
  _shmem_metrics                 | 
+ _wake_workers                  | p_id bigint, p_ordering_key text
  alter_endpoint                 | endpoint_name text, new_config jsonb
  archive_completed_messages     | p_older_than_seconds integer DEFAULT 3600, p_batch_size integer DEFAULT 1000
  archive_single_to_dlq          | p_message_id bigint
@@ -146,7 +147,7 @@ ORDER BY p.proname;
  update_circuit_breaker         | p_endpoint_id bigint, p_success boolean
  update_updated_at              | 
  validate_endpoint_config       | protocol text, config jsonb
-(42 rows)
+(43 rows)
 
 -- ============================================================================
 -- TRIGGERS

--- a/tests/regress/expected/26_wake.out
+++ b/tests/regress/expected/26_wake.out
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Test: worker wake-up path (ulak._wake_workers) and its GUCs
+-- ============================================================================
+-- 1. Defaults: in-database workers are woken through shared memory, no NOTIFY
+SHOW ulak.wake_notify;
+ ulak.wake_notify 
+------------------
+ off
+(1 row)
+
+SHOW ulak.notify_throttle_ms;
+ ulak.notify_throttle_ms 
+-------------------------
+ 100
+(1 row)
+
+-- 2. Callable with an unknown row (wake all), an unkeyed row and a keyed row
+SELECT ulak._wake_workers(NULL, NULL);
+ _wake_workers 
+---------------
+ 
+(1 row)
+
+SELECT ulak._wake_workers(42, NULL);
+ _wake_workers 
+---------------
+ 
+(1 row)
+
+SELECT ulak._wake_workers(42, 'order-1');
+ _wake_workers 
+---------------
+ 
+(1 row)
+
+-- 3. The queue trigger and the batch/publish APIs route through it
+SELECT pg_get_functiondef('ulak.notify_new_message'::regproc) LIKE '%ulak._wake_workers(NULL, NULL)%' AS trigger_uses_wake;
+ trigger_uses_wake 
+-------------------
+ t
+(1 row)
+
+SELECT count(*) AS functions_calling_pg_notify
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'ulak' AND p.prosrc LIKE '%pg_notify%';
+ functions_calling_pg_notify 
+-----------------------------
+                           0
+(1 row)
+
+-- 4. send() and send_with_options() still enqueue (the wake happens at commit)
+INSERT INTO ulak.endpoints (name, protocol, config, enabled)
+VALUES ('wake_ep', 'http', '{"url": "https://example.com/wake"}'::jsonb, false);
+BEGIN;
+UPDATE ulak.endpoints SET enabled = true WHERE name = 'wake_ep';
+SELECT ulak.send('wake_ep', '{"n": 1}'::jsonb);
+ send 
+------
+ t
+(1 row)
+
+SELECT ulak.send_with_options('wake_ep', '{"n": 2}'::jsonb, 0::smallint, NULL, NULL, NULL, NULL, 'key-1') > 0 AS keyed_send;
+ keyed_send 
+------------
+ t
+(1 row)
+
+SELECT count(*) AS queued FROM ulak.queue q JOIN ulak.endpoints e ON e.id = q.endpoint_id WHERE e.name = 'wake_ep';
+ queued 
+--------
+      2
+(1 row)
+
+ROLLBACK;
+DELETE FROM ulak.endpoints WHERE name = 'wake_ep';

--- a/tests/regress/sql/00_setup.sql
+++ b/tests/regress/sql/00_setup.sql
@@ -7,6 +7,9 @@ CREATE EXTENSION ulak;
 -- Allow internal URLs for testing (SSRF protection blocks localhost by default)
 ALTER SYSTEM SET ulak.http_allow_internal_urls = true;
 SELECT pg_reload_conf();
+-- The reload reaches this backend asynchronously (SIGHUP relayed by the
+-- postmaster); set it for this session too so the endpoint below never races it.
+SET ulak.http_allow_internal_urls = true;
 
 -- Verify extension is installed
 SELECT extname, extversion IS NOT NULL AS has_version FROM pg_extension WHERE extname = 'ulak';

--- a/tests/regress/sql/26_wake.sql
+++ b/tests/regress/sql/26_wake.sql
@@ -1,0 +1,29 @@
+-- ============================================================================
+-- Test: worker wake-up path (ulak._wake_workers) and its GUCs
+-- ============================================================================
+
+-- 1. Defaults: in-database workers are woken through shared memory, no NOTIFY
+SHOW ulak.wake_notify;
+SHOW ulak.notify_throttle_ms;
+
+-- 2. Callable with an unknown row (wake all), an unkeyed row and a keyed row
+SELECT ulak._wake_workers(NULL, NULL);
+SELECT ulak._wake_workers(42, NULL);
+SELECT ulak._wake_workers(42, 'order-1');
+
+-- 3. The queue trigger and the batch/publish APIs route through it
+SELECT pg_get_functiondef('ulak.notify_new_message'::regproc) LIKE '%ulak._wake_workers(NULL, NULL)%' AS trigger_uses_wake;
+SELECT count(*) AS functions_calling_pg_notify
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'ulak' AND p.prosrc LIKE '%pg_notify%';
+
+-- 4. send() and send_with_options() still enqueue (the wake happens at commit)
+INSERT INTO ulak.endpoints (name, protocol, config, enabled)
+VALUES ('wake_ep', 'http', '{"url": "https://example.com/wake"}'::jsonb, false);
+BEGIN;
+UPDATE ulak.endpoints SET enabled = true WHERE name = 'wake_ep';
+SELECT ulak.send('wake_ep', '{"n": 1}'::jsonb);
+SELECT ulak.send_with_options('wake_ep', '{"n": 2}'::jsonb, 0::smallint, NULL, NULL, NULL, NULL, 'key-1') > 0 AS keyed_send;
+SELECT count(*) AS queued FROM ulak.queue q JOIN ulak.endpoints e ON e.id = q.endpoint_id WHERE e.name = 'wake_ep';
+ROLLBACK;
+DELETE FROM ulak.endpoints WHERE name = 'wake_ep';


### PR DESCRIPTION
## Summary

Wake the in-database workers through shared memory when a sending transaction commits instead of a `NOTIFY` per insert, claim each batch in its own committed transaction and deliver with no transaction open, and bound Redis host name resolution by `connect_timeout`.

## Why

Three problems, each measured before the fix:

- `NOTIFY ulak_new_msg` on every insert serialised all sending commits behind PostgreSQL's notification lock: `ulak.send()` capped at ~500 tx/s with 8 or 32 clients while a plain insert did 18k. With the commit-time latch: 1107 tx/s at 8 clients, 2766 at 32; idle-worker-to-delivered latency unchanged (median 8 ms). A message can now also be sent inside `PREPARE TRANSACTION`. External processes that `LISTEN` on the channel need `ulak.wake_notify = on` (throttled by `ulak.notify_throttle_ms`) — this is the breaking change of the `feat(worker)!` commit and the reason the next release is 0.2.0.
- A batch held one transaction across `FOR UPDATE SKIP LOCKED`, dispatch and the status updates, so an unreachable broker kept row locks, an xid and an old snapshot for the whole delivery timeout (30 s for Kafka) and the rows were invisible as `processing`. The claim now commits first, delivery runs with no transaction, results are written in a second transaction; a heartbeat keeps stale recovery away from long batches, every result update is guarded with `status = 'processing'`, and an error between claim and write releases the rows immediately.
- hiredis resolves the host with a blocking `getaddrinfo()` outside its own connect timeout, so a broken DNS record stalled the worker for 8–15 s whatever `connect_timeout` said. The name is now resolved on a bounded helper thread and cached for 60 s.

Upgrade path: `sql/ulak--0.1.2--0.2.0.sql` (checked to produce the same schema as a fresh install; `ALTER EXTENSION ulak UPDATE TO '0.2.0'` verified).

## Validation

- [x] `make format` (clang-format clean on all touched files)
- [x] `make lint` (cppcheck clean; clang-tidy with the CI gate flags exits 0)
- [x] `make hooks-run` or local `lefthook` hooks (pre-commit and commit-msg hooks passed on every commit)
- [x] `make installcheck` (PG 18: 28 regress, 13 isolation; TAP 5/5 including the new `004_wake_latency` and `005_claim_before_delivery`)

Also run locally: HTTP e2e 39/39 and 30/34 (4 skipped), Kafka 17/17, Redis 16/16, MQTT 14/14, NATS 14/14, AMQP 13/13. The wake commit alone was additionally verified on PG 14 and 15 (build, regress, isolation, TAP); the combined branch relies on the CI matrix for PG 14–17.

## Checklist

- [x] Tests added or updated when behavior changed (regress `26_wake`, TAP `004`/`005`; Kafka, Redis and AMQP unreachable-broker e2e tests wait for the recorded retry; AMQP helper declares durable queues for RabbitMQ 4)
- [x] Docs updated when user-facing behavior or operations changed (README configuration table; wiki pages prepared in the submodule, to be pushed with the release)
- [x] Commit messages follow the repository convention
- [x] This PR is ready for review

Merge with a merge commit (not squash) so the three commits keep their types and the `!` marker for release-please.
